### PR TITLE
Update client.go to use mounted namespace if NAMESPACE env variable is not available (leader election)

### DIFF
--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -367,6 +367,10 @@ func (client Client) GetLeaseHolder() (<-chan string, error) {
 	leaseHolderChan = make(chan string, 20)
 	namespace := os.Getenv("NAMESPACE")
 	if namespace == "" {
+	        if ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+			namespace = string(ns)
+		} 
+		
 		namespace = "falco"
 	}
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{

--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -367,12 +367,13 @@ func (client Client) GetLeaseHolder() (<-chan string, error) {
 	leaseHolderChan = make(chan string, 20)
 	namespace := os.Getenv("NAMESPACE")
 	if namespace == "" {
-	        if ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 			namespace = string(ns)
-		} 
-		
-		namespace = "falco"
+		} else {
+			namespace = "falco"
+		}
 	}
+
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file and learn how to compile Falco from source [here](https://falco.org/docs/source).
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug
> /kind cleanup
> /kind design
> /kind documentation
/kind enhancement
> /kind failing-test
> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area actionners
> /area build

/area config

> /area context
> /area core
> /area notifiers
> /area ouputs
> /area rule-engine 

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / Why we need it**:
This PR enhances the namespace detection logic for the LeaseHolder function by adding a fallback mechanism to read the namespace from the Kubernetes service account when the NAMESPACE environment variable is not set. This follows Kubernetes best practices by checking the standard location where namespace information is mounted in pods. And it also fixes a bug where deploying talon to non-falco namespace keeps printing an error related to this line. 

**How to reproduce the issue**:
Deploy Falco Talon to a Kubernetes cluster without setting the NAMESPACE environment variable. Without this change, the system would always default to the "falco" namespace rather than detecting the actual namespace from the service account.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

**Special notes for your reviewer**:
This change maintains backwards compatibility by falling back to the "falco" default namespace if neither the environment variable nor the service account namespace information is available. The code change is minimal and follows the existing pattern while adding the additional detection capability.