### PR TITLE
fix: handle custom_headers notifier config without panicking

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -214,7 +214,18 @@ func SetFields(structure any, fields map[string]any) any {
 					valueOf.Field(i).SetBool(d)
 				}
 			case MapStringStr:
-				valueOf.Field(i).SetMapIndex(reflect.ValueOf(fields[field]), reflect.ValueOf(fields[field]).Elem())
+				headers := make(map[string]string)
+				switch typed := fields[field].(type) {
+				case map[string]string:
+					for key, value := range typed {
+						headers[key] = value
+					}
+				case map[string]any:
+					for key, value := range typed {
+						headers[key] = fmt.Sprint(value)
+					}
+				}
+				valueOf.Field(i).Set(reflect.ValueOf(headers))
 			}
 		} else if deflt != "" {
 			switch valueOf.Type().Field(i).Type.String() {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,44 @@
+package utils
+
+import "testing"
+
+func TestSetFieldsSetsMapStringFieldFromMapAny(t *testing.T) {
+	type parameters struct {
+		CustomHeaders map[string]string `field:"custom_headers"`
+	}
+
+	result := SetFields(&parameters{}, map[string]any{
+		"custom_headers": map[string]any{
+			"Authorization": "Bearer token",
+			"X-Retry":       3,
+		},
+	}).(*parameters)
+
+	if len(result.CustomHeaders) != 2 {
+		t.Fatalf("expected 2 headers, got %d", len(result.CustomHeaders))
+	}
+
+	if got := result.CustomHeaders["Authorization"]; got != "Bearer token" {
+		t.Fatalf("expected Authorization header to be preserved, got %q", got)
+	}
+
+	if got := result.CustomHeaders["X-Retry"]; got != "3" {
+		t.Fatalf("expected X-Retry header to be stringified, got %q", got)
+	}
+}
+
+func TestSetFieldsSetsMapStringFieldFromMapString(t *testing.T) {
+	type parameters struct {
+		CustomHeaders map[string]string `field:"custom_headers"`
+	}
+
+	result := SetFields(&parameters{}, map[string]any{
+		"custom_headers": map[string]string{
+			"X-Test": "value",
+		},
+	}).(*parameters)
+
+	if got := result.CustomHeaders["X-Test"]; got != "value" {
+		t.Fatalf("expected X-Test header to be preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
/kind bug
/area notifiers

What this PR does / Why we need it:

Using `custom_headers` in notifier config could panic during init. YAML gives `map[string]any`, but `utils.SetFields` handled `map[string]string` fields with broken reflection logic. This was a sneaky footgun for `webhook` and `elasticsearch`.

This patch converts both `map[string]any` and `map[string]string` into the target `map[string]string`, and adds a small regression test.

How to reproduce the issue:

```go
package main

import (
  "gopkg.in/yaml.v3"
  "github.com/falcosecurity/falco-talon/notifiers/webhook"
)

func main() {
  cfg := []byte("url: http://example.com\ncustom_headers:\n  Authorization: Bearer token\n")
  fields := map[string]any{}
  _ = yaml.Unmarshal(cfg, &fields)
  _ = (webhook.Notifier{}).Init(fields)
}
```

Before this fix it panics with `reflect: call of reflect.Value.Elem on map Value`.
After this fix it just works, nice and boring.

Which issue(s) this PR fixes:

None

Special notes for your reviewer:

Verified with `go test ./...` and `go test ./... -race`.
