### PR TITLE
fix: report the failing rules file in parse errors

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -246,10 +246,10 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 		}
 
 		if err := yaml.Unmarshal(f, &at); err != nil {
-			return nil, nil, fmt.Errorf("wrong syntax for the rule file '%v': %v", files[0], err.Error())
+			return nil, nil, fmt.Errorf("wrong syntax for the rule file '%v': %v", i, err.Error())
 		}
 		if err := yaml.Unmarshal(f, &rt); err != nil {
-			return nil, nil, fmt.Errorf("wrong syntax for the rule file '%v': %v", files[0], err.Error())
+			return nil, nil, fmt.Errorf("wrong syntax for the rule file '%v': %v", i, err.Error())
 		}
 
 		a = append(a, at...)

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractActionsRulesReportsTheBrokenFileName(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	validRulesFile := filepath.Join(tmpDir, "valid-rules.yaml")
+	if err := os.WriteFile(validRulesFile, []byte(`
+- rule: valid
+  description: valid rule
+  actions: []
+  notifiers: []
+  match: {}
+`), 0o600); err != nil {
+		t.Fatalf("write valid rules file: %v", err)
+	}
+
+	brokenRulesFile := filepath.Join(tmpDir, "broken-rules.yaml")
+	if err := os.WriteFile(brokenRulesFile, []byte(`
+- rule: broken
+  description: [
+`), 0o600); err != nil {
+		t.Fatalf("write broken rules file: %v", err)
+	}
+
+	_, _, err := extractActionsRules([]string{validRulesFile, brokenRulesFile})
+	if err == nil {
+		t.Fatal("expected invalid YAML to return an error")
+	}
+
+	if !strings.Contains(err.Error(), brokenRulesFile) {
+		t.Fatalf("expected error to mention %q, got %q", brokenRulesFile, err.Error())
+	}
+}


### PR DESCRIPTION
/kind bug
/area rule-engine

**What this PR does / Why we need it**:

When `rules_files` has more than one file and a later file has bad YAML, Talon reports the first file in the error. Thats pretty annoying to debug. This patch reports the actual file and adds a regression test.

**How to reproduce the issue**:

1. Configure `rules_files` with at least 2 files.
2. Keep the first file valid.
3. Put invalid YAML in the second file.
4. Parse the rules.
5. Before this patch, the error points to the first file.

You can also see it with `go test ./internal/rules -run TestExtractActionsRulesReportsTheBrokenFileName` on the parent commit.

**Which issue(s) this PR fixes**:

N/A, I couldnt find a matching issue.

**Special notes for your reviewer**:

Tiny fix, no behavior change besides the error message.
