### PR TITLE
fix: allow overriding otel.timeout

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -98,7 +98,7 @@ func CreateConfiguration(configFile string) *Configuration {
 	v.SetDefault("otel.metrics_enabled", defaultOtelCollectorMetricsEnabled)
 	v.SetDefault("otel.collector_endpoint", defaultOtelCollectorEndpoint)
 	v.SetDefault("otel.collector_port", defaultOtelCollectorPort)
-	v.Set("otel.timeout", defaultOtelCollectorGRPCTimeout)
+	v.SetDefault("otel.timeout", defaultOtelCollectorGRPCTimeout)
 	v.SetDefault("otel.collector_use_insecure_grpc", defaultOtelCollectorUseInsecureGrpc)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,43 @@
+package configuration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func resetConfigForTest() {
+	config = new(Configuration)
+}
+
+func TestCreateConfigurationAllowsOverridingOtelTimeoutFromFile(t *testing.T) {
+	t.Cleanup(resetConfigForTest)
+	resetConfigForTest()
+
+	tmpDir := t.TempDir()
+	configFile := filepath.Join(tmpDir, "config.yaml")
+	if err := os.WriteFile(configFile, []byte(`
+otel:
+  timeout: 42
+`), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	cfg := CreateConfiguration(configFile)
+
+	if cfg.Otel.Timeout != 42 {
+		t.Fatalf("expected otel timeout from config file to be applied, got %d", cfg.Otel.Timeout)
+	}
+}
+
+func TestCreateConfigurationAllowsOverridingOtelTimeoutFromEnv(t *testing.T) {
+	t.Cleanup(resetConfigForTest)
+	resetConfigForTest()
+	t.Setenv("OTEL_TIMEOUT", "37")
+
+	cfg := CreateConfiguration("")
+
+	if cfg.Otel.Timeout != 37 {
+		t.Fatalf("expected otel timeout from env to be applied, got %d", cfg.Otel.Timeout)
+	}
+}


### PR DESCRIPTION
/kind bug
/area config

What this PR does / Why we need it:

`otel.timeout` is documented as configurable, but the loader used `v.Set(...)` for this one key. So YAML and `OTEL_TIMEOUT` overrides get ignored, and it stays pinned to `10`. Kinda sneaky bug. This switches it to `SetDefault(...)` and adds regression tests.

How to reproduce the issue:

1. Put this in `config.yaml`:

```yaml
otel:
  timeout: 42
```

2. Run `go test ./configuration -run TestCreateConfigurationAllowsOverridingOtelTimeoutFromFile` on the parent commit.
3. Before this fix, it fails with `expected otel timeout from config file to be applied, got 10`.
4. You can also set `OTEL_TIMEOUT=37` and run `go test ./configuration -run TestCreateConfigurationAllowsOverridingOtelTimeoutFromEnv` on the parent commit. Same deal, it still gets `10`.

Which issue(s) this PR fixes:

N/A, didnt find a matching issue.

Special notes for your reviewer:

Low risk fix. `otel.timeout` is already in `config_example.yaml`, and both OTLP exporters already read `config.Otel.Timeout`, so this just makes the documented override actually work. No external quota or API limit blocks this bug, it happens in local config parsing before any network call.
