### PR TITLE
docs: fix Helm install command and config example comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ To generate the images to test locally you can run `mage buildImagesLocal`
 The helm chart is available in the repo [`charts`](https://github.com/falcosecurity/charts/tree/master/charts/falco-talon).
 
 Two config files are provided:
-* `values.yaml` allows you to configure `Falcon Talon` and the deployment, the list of available values is [here](https://github.com/falcosecurity/charts/tree/master/charts/falco-talon#configuration)
+* `values.yaml` allows you to configure `Falco Talon` and the deployment, the list of available values is [here](https://github.com/falcosecurity/charts/tree/master/charts/falco-talon#configuration)
 * `rules.yaml` contains rules to set
 
 ```shell
 helm repo add falcosecurity https://falcosecurity.github.io/charts
 helm repo update
-helm install falco-talon falcosecurity/falco -n falco --create-namespace
+helm install falco-talon falcosecurity/falco-talon -n falco --create-namespace
 ```
 
 #### Configure Falcosidekick
@@ -160,4 +160,3 @@ Falco Talon is licensed to you under the [Apache 2.0](./LICENSE) open source lic
 ## Author
 
 Thomas Labarussias (https://github.com/Issif)
-

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,8 +1,8 @@
 listen_address: "0.0.0.0" # default: "0.0.0.0"
 listen_port: "2803" # default: "2803"
 rules_files:
-  - "./rules.yaml" # default: "./rules.yaml"
-# kubeConfig: "~/.kube/config" # only if Falco Talon is running outside Kubernetes
+  - "./rules.yaml" # example value, default: "/etc/falco-talon/rules.yaml"
+# kubeconfig: "~/.kube/config" # only if Falco Talon is running outside Kubernetes
 log_format: "color" # log Format: text, color, json (default: color)
 watch_rules: true # reload if the rules files changes (default: true)
 print_all_events: true # print in logs all received events, not only those which match


### PR DESCRIPTION
/kind documentation
/area config

**What this PR does / Why we need it**:
Small doc drift fix. The README Helm command points to `falcosecurity/falco`, so it installs the `falco` chart, not Talon. `config_example.yaml` also had the wrong default `rules_files` comment, and the commented key should be `kubeconfig`.

**How to reproduce the issue**:
1. Run `helm repo add falcosecurity https://falcosecurity.github.io/charts` and `helm repo update`.
2. Run `helm show chart falcosecurity/falco | rg "^name:"`.
3. Run `helm show chart falcosecurity/falco-talon | rg "^name:"`.
4. The old README command uses the chart from step 2, so yeah, it pulls `falco`, not `falco-talon`.
5. Compare `config_example.yaml` with `configuration/configuration.go`; the example said default `./rules.yaml`, but the code default is `/etc/falco-talon/rules.yaml`.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
Tiny paper cut, no runtime behavior change.
