### PR TITLE
fix: correct notifier CLI metadata examples

### DIFF
--- a/cmd/notifiers.go
+++ b/cmd/notifiers.go
@@ -59,7 +59,11 @@ var notifiersListCmd = &cobra.Command{
 				a.Parameters = parameters
 			}
 			yamla, _ := yaml.Marshal(a)
-			fmt.Printf("--- %v ---\n\n", i.Information().FullName)
+			header := i.Information().FullName
+			if header == "" {
+				header = i.Information().Name
+			}
+			fmt.Printf("--- %v ---\n\n", header)
 			fmt.Println(string(yamla))
 		}
 	},

--- a/cmd/notifiers_test.go
+++ b/cmd/notifiers_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	output := <-done
+	_ = r.Close()
+
+	return output
+}
+
+func TestNotifiersListUsesNotifierNameWhenFullNameIsEmpty(t *testing.T) {
+	output := captureStdout(t, func() {
+		notifiersListCmd.Run(nil, nil)
+	})
+
+	if strings.Contains(output, "---  ---") {
+		t.Fatalf("expected notifier list header fallback to avoid empty headers, got output:\n%s", output)
+	}
+
+	for _, header := range []string{"--- slack ---", "--- loki ---", "--- elasticsearch ---"} {
+		if !strings.Contains(output, header) {
+			t.Fatalf("expected notifier list output to contain %q, got output:\n%s", header, output)
+		}
+	}
+}

--- a/notifiers/elasticsearch/elasticsearch.go
+++ b/notifiers/elasticsearch/elasticsearch.go
@@ -22,13 +22,8 @@ const (
     create_index_template: true
     number_of_shards: 1
     number_of_replicas: 1
-notifiers:
-  slack:
-    webhook_url: "https://hooks.slack.com/services/XXXX"
-    icon: "https://upload.wikimedia.org/wikipedia/commons/2/26/Circaetus_gallicus_claw.jpg"
-    username: "Falco Talon"
-    footer: "https://github.com/falcosecurity/falco-talon"
-    format: long
+    index: "falco-talon"
+    suffix: "daily"
 `
 )
 

--- a/notifiers/elasticsearch/elasticsearch_test.go
+++ b/notifiers/elasticsearch/elasticsearch_test.go
@@ -1,0 +1,15 @@
+package elasticsearch
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExampleOnlyDocumentsElasticsearchNotifier(t *testing.T) {
+	if strings.Contains(Example, "slack:") {
+		t.Fatalf("expected elasticsearch example not to include unrelated slack notifier config, got:\n%s", Example)
+	}
+	if strings.Count(Example, "notifiers:") != 1 {
+		t.Fatalf("expected elasticsearch example to contain a single notifiers block, got:\n%s", Example)
+	}
+}

--- a/notifiers/loki/loki.go
+++ b/notifiers/loki/loki.go
@@ -17,7 +17,7 @@ const (
 	Permissions string = ""
 	Example     string = `notifiers:
   loki:
-    host_port: "https://lolcalhost:3100"
+    url: "https://localhost:3100"
     user: "xxxxx"
     api_key: "xxxxx"
 `
@@ -75,7 +75,7 @@ func (n Notifier) Parameters() models.Parameters {
 
 func (n Notifier) Run(log utils.LogLine) error {
 	if parameters.URL == "" {
-		return errors.New("wrong `host_port` setting")
+		return errors.New("wrong `url` setting")
 	}
 
 	if err := http.CheckURL(parameters.URL); err != nil {
@@ -101,7 +101,7 @@ func (n Notifier) Run(log utils.LogLine) error {
 
 func checkParameters(parameters *Parameters) error {
 	if parameters.URL == "" {
-		return errors.New("wrong `host_port` setting")
+		return errors.New("wrong `url` setting")
 	}
 
 	if err := utils.ValidateStruct(parameters); err != nil {

--- a/notifiers/loki/loki_test.go
+++ b/notifiers/loki/loki_test.go
@@ -1,0 +1,15 @@
+package loki
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExampleUsesURLSetting(t *testing.T) {
+	if !strings.Contains(Example, "url:") {
+		t.Fatalf("expected loki example to use url setting, got:\n%s", Example)
+	}
+	if strings.Contains(Example, "host_port:") {
+		t.Fatalf("expected loki example to stop using host_port setting, got:\n%s", Example)
+	}
+}


### PR DESCRIPTION
/kind bug
/area notifiers

What this PR does / Why we need it:
`notifiers list` prints blank headers for notifiers, and the Loki and Elasticsearch examples are a bit off. This makes the header fall back to the notifier name and cleans the shipped examples so they match the real fields.

How to reproduce the issue:
1. Run `go run . notifiers list`
2. See blank `---  ---` headers
3. See the Loki example using `host_port` even though the setting is `url`
4. See the Elasticsearch example carrying an unrelated Slack block

Which issue(s) this PR fixes:
N/A

Special notes for your reviewer:
Added small tests for the CLI output and example strings. pretty low drama fix, just makes the generated help less wonky.