### PR TITLE
fix: honor cilium allow_namespaces without allow_cidr

### DIFF
--- a/actionners/cilium/networkpolicy/networkpolicy.go
+++ b/actionners/cilium/networkpolicy/networkpolicy.go
@@ -373,7 +373,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 }
 
 func createAllowNamespaceEgressRule(parameters Parameters) *api.EgressRule {
-	if len(parameters.AllowCIDR) == 0 {
+	if len(parameters.AllowNamespaces) == 0 {
 		return nil
 	}
 

--- a/actionners/cilium/networkpolicy/networkpolicy_test.go
+++ b/actionners/cilium/networkpolicy/networkpolicy_test.go
@@ -1,0 +1,36 @@
+package networkpolicy
+
+import "testing"
+
+func TestCreateAllowNamespaceEgressRuleUsesAllowNamespaces(t *testing.T) {
+	rule := createAllowNamespaceEgressRule(Parameters{
+		AllowNamespaces: []string{"blue-ns", "green-ns"},
+	})
+
+	if rule == nil {
+		t.Fatal("expected a namespace egress rule when allow_namespaces is configured")
+	}
+
+	if len(rule.ToEndpoints) != 1 {
+		t.Fatalf("expected one endpoint selector, got %d", len(rule.ToEndpoints))
+	}
+
+	selector := rule.ToEndpoints[0].LabelSelector
+	if selector == nil {
+		t.Fatal("expected namespace rule to define a label selector")
+	}
+
+	if len(selector.MatchExpressions) != 1 {
+		t.Fatalf("expected one match expression, got %d", len(selector.MatchExpressions))
+	}
+
+	expr := selector.MatchExpressions[0]
+	if expr.Key != namespaceKey {
+		t.Fatalf("expected selector key %q, got %q", namespaceKey, expr.Key)
+	}
+
+	if len(expr.Values) != 2 || expr.Values[0] != "blue-ns" || expr.Values[1] != "green-ns" {
+		t.Fatalf("expected selector values to preserve configured namespaces, got %#v", expr.Values)
+	}
+}
+


### PR DESCRIPTION
/kind bug
/area actionners

What this PR does / Why we need it:
Fixes `cilium:networkpolicy` so `allow_namespaces` works on its own. The helper was checking `AllowCIDR` by mistake, so a namespace-only config was silently ignored. pretty sneaky bug.

How to reproduce the issue:
1. On `main`, use a config like:
   ```yaml
   parameters:
     allow_namespaces:
       - blue-ns
   ```
2. Call `createAllowNamespaceEgressRule(Parameters{AllowNamespaces: []string{"blue-ns"}})`
3. It returns `nil`, so no namespace allow rule is created.
4. Run `go test ./actionners/cilium/networkpolicy` with the added regression test from this PR, it fails on `main` and passes with this fix.

Which issue(s) this PR fixes:
n/a
Related to #279 and PR #305.

Special notes for your reviewer:
Added one small regression test. `go test ./...` is green.
