### PR TITLE
fix: populate SMTP text notifier body

### DIFF
--- a/notifiers/smtp/smtp.go
+++ b/notifiers/smtp/smtp.go
@@ -162,6 +162,13 @@ func NewPayload(log utils.LogLine) (Payload, error) {
 	}
 
 	if parameters.Format == Text {
+		payload.Body = fmt.Sprintf("%v\n%v\n%v\n%v\n\n%v",
+			payload.From,
+			payload.To,
+			payload.Date,
+			payload.Subject,
+			outtext.String(),
+		)
 		return payload, nil
 	}
 

--- a/notifiers/smtp/smtp_test.go
+++ b/notifiers/smtp/smtp_test.go
@@ -1,0 +1,51 @@
+package smtp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/falcosecurity/falco-talon/utils"
+)
+
+func TestNewPayloadTextFormatIncludesPlainTextBody(t *testing.T) {
+	parameters = &Parameters{
+		From:   "falco@example.com",
+		To:     "user@example.com",
+		Format: Text,
+	}
+
+	payload, err := NewPayload(utils.LogLine{
+		Status:       utils.SuccessStr,
+		Message:      "action completed",
+		Rule:         "Terminal shell in container",
+		Action:       "notify",
+		TraceID:      "trace-123",
+		Objects:      map[string]string{"Pod": "nginx"},
+		Error:        "sample error",
+		Result:       "sample result",
+		Output:       "sample output",
+		OutputTarget: "local:file",
+	})
+	if err != nil {
+		t.Fatalf("NewPayload returned error: %v", err)
+	}
+
+	if payload.Body == "" {
+		t.Fatal("expected text payload body to be populated")
+	}
+
+	for _, part := range []string{
+		"Subject: [falco-talon][success][action completed]",
+		"From: falco@example.com",
+		"To: user@example.com",
+		"Status: success",
+		"Rule: Terminal shell in container",
+		"Action: notify",
+		"Pod: nginx",
+		"Trace ID: trace-123",
+	} {
+		if !strings.Contains(payload.Body, part) {
+			t.Fatalf("expected payload body to contain %q, got:\n%s", part, payload.Body)
+		}
+	}
+}


### PR DESCRIPTION
What type of PR is this?

/kind bug

Any specific area of the project related to this PR?

/area notifiers

What this PR does / Why we need it:

Fixes SMTP `format: text` notifications sending an empty body. `NewPayload` rendered the plaintext template, then bailed out before copying it into `payload.Body`, so text mails were blank. Tiny fix, plus a regression test so it doesnt slip back.

How to reproduce the issue:

1. Configure the SMTP notifier with `format: text`.
2. Trigger any notification that goes through SMTP.
3. On `main`, `notifiers/smtp.NewPayload` returns early with `payload.Body` still empty, so the sent mail has no body.

A quick check is `go test ./notifiers/smtp` with the added regression test. It fails on `main`, passes with this patch.

Which issue(s) this PR fixes:

None found.

Special notes for your reviewer:

I also ran `go test ./...` and `go run github.com/magefile/mage@latest test` locally.
