### PR TITLE
fix: return output check failures from runAction

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -342,7 +342,7 @@ func runAction(mctx context.Context, rule *rules.Rule, action *rules.Action, eve
 			span.RecordError(err2)
 			go notifiers.Notify(octx, rule, action, event, logO)
 			span.End()
-			return err
+			return err2
 		}
 
 		result, err = o.Run(output, data)

--- a/actionners/actionners_test.go
+++ b/actionners/actionners_test.go
@@ -1,0 +1,84 @@
+package actionners
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/falcosecurity/falco-talon/configuration"
+	"github.com/falcosecurity/falco-talon/internal/events"
+	"github.com/falcosecurity/falco-talon/internal/models"
+	"github.com/falcosecurity/falco-talon/internal/otlp/metrics"
+	"github.com/falcosecurity/falco-talon/internal/otlp/traces"
+	"github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/utils"
+)
+
+type requireOutputActionnerStub struct{}
+
+func (a requireOutputActionnerStub) Init() error { return nil }
+
+func (a requireOutputActionnerStub) Run(_ *events.Event, _ *rules.Action) (utils.LogLine, *models.Data, error) {
+	return utils.LogLine{Status: utils.SuccessStr}, &models.Data{
+		Name:    "artifact.txt",
+		Objects: map[string]string{"pod": "demo"},
+		Bytes:   []byte("payload"),
+	}, nil
+}
+
+func (a requireOutputActionnerStub) CheckParameters(_ *rules.Action) error { return nil }
+
+func (a requireOutputActionnerStub) Checks(_ *events.Event, _ *rules.Action) error { return nil }
+
+func (a requireOutputActionnerStub) Information() models.Information {
+	return models.Information{
+		Name:          "stub",
+		FullName:      "tests:stub",
+		Category:      "tests",
+		RequireOutput: true,
+	}
+}
+
+func (a requireOutputActionnerStub) Parameters() models.Parameters { return nil }
+
+func TestRunActionReturnsOutputCheckErrors(t *testing.T) {
+	configuration.CreateConfiguration("")
+	metrics.Init()
+	shutdown, err := traces.SetupOTelSDK(context.Background())
+	if err != nil {
+		t.Fatalf("setup traces: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = shutdown(context.Background())
+	})
+
+	previousEnabled := enabledActionners
+	enabledActionners = &Actionners{requireOutputActionnerStub{}}
+	t.Cleanup(func() {
+		enabledActionners = previousEnabled
+	})
+
+	action := &rules.Action{
+		Name:         "capture",
+		Actionner:    "tests:stub",
+		Continue:     falseStr,
+		IgnoreErrors: falseStr,
+		Output: rules.Output{
+			Target: "local:file",
+			Parameters: map[string]any{
+				"destination": t.TempDir() + "/missing",
+			},
+		},
+	}
+	rule := &rules.Rule{Name: "rule"}
+	event := &events.Event{Output: "event", TraceID: "trace-id"}
+
+	err = runAction(context.Background(), rule, action, event)
+	if err == nil {
+		t.Fatal("expected output checks failure to be returned")
+	}
+
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("expected missing destination error, got %v", err)
+	}
+}

--- a/actionners/cilium/networkpolicy/networkpolicy_test.go
+++ b/actionners/cilium/networkpolicy/networkpolicy_test.go
@@ -33,4 +33,3 @@ func TestCreateAllowNamespaceEgressRuleUsesAllowNamespaces(t *testing.T) {
 		t.Fatalf("expected selector values to preserve configured namespaces, got %#v", expr.Values)
 	}
 }
-


### PR DESCRIPTION
/kind bug
/area actionners

What this PR does / Why we need it:
`runAction` logs output check failures for required-output actionners, but on `main` it returns `err` instead of `err2` in that branch. `err` is still `nil` there, so the caller can keep going like the action worked. pretty sneaky bug. This patch returns the real error and adds a small regression test, so it doesnt slip back.

How to reproduce the issue:
1. On `main`, run `go test ./actionners -run TestRunActionReturnsOutputCheckErrors -v`
2. The test uses a required-output action with `target: local:file` and `destination` set to a missing dir
3. You get `folder '.../missing' does not exist` in logs, but `runAction` returns `nil`, so the test fails
4. With this patch, the same test passes and the error is propagated

Which issue(s) this PR fixes:
n/a
I didnt find a direct issue or PR for this exact bug.

Special notes for your reviewer:
`go test ./...` is green.
