### PR TITLE
fix: unify rule validation during watched reloads

### DIFF
--- a/cmd/rule_validation.go
+++ b/cmd/rule_validation.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"github.com/falcosecurity/falco-talon/actionners"
+	ruleengine "github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/outputs"
+	"github.com/falcosecurity/falco-talon/utils"
+)
+
+func validateRules(rules *[]*ruleengine.Rule) bool {
+	defaultActionners := actionners.ListDefaultActionners()
+	defaultOutputs := outputs.ListDefaultOutputs()
+
+	valid := true
+	for _, rule := range *rules {
+		for _, action := range rule.GetActions() {
+			actionner := defaultActionners.FindActionner(action.GetActionner())
+			if actionner == nil {
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{
+					Error:     "unknown actionner",
+					Rule:      rule.GetName(),
+					Action:    action.GetName(),
+					Actionner: action.GetActionner(),
+					Message:   "rules",
+				})
+				valid = false
+				continue
+			}
+
+			if err := actionner.CheckParameters(action); err != nil {
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{
+					Error:     err.Error(),
+					Rule:      rule.GetName(),
+					Action:    action.GetName(),
+					Actionner: action.GetActionner(),
+					Message:   "rules",
+				})
+				valid = false
+			}
+
+			output := action.GetOutput()
+			if output == nil {
+				if actionner.Information().RequireOutput {
+					utils.PrintLog(utils.ErrorStr, utils.LogLine{
+						Error:     "an output is required",
+						Rule:      rule.GetName(),
+						Action:    action.GetName(),
+						Actionner: action.GetActionner(),
+						Message:   "rules",
+					})
+					valid = false
+				}
+				continue
+			}
+
+			target := defaultOutputs.FindOutput(output.GetTarget())
+			if target == nil {
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{
+					Error:        "unknown target",
+					Rule:         rule.GetName(),
+					Action:       action.GetName(),
+					OutputTarget: output.GetTarget(),
+					Message:      "rules",
+				})
+				valid = false
+				continue
+			}
+
+			if len(output.Parameters) == 0 {
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{
+					Error:        "missing parameters for the output",
+					Rule:         rule.GetName(),
+					Action:       action.GetName(),
+					OutputTarget: output.GetTarget(),
+					Message:      "rules",
+				})
+				valid = false
+				continue
+			}
+
+			if err := target.CheckParameters(output); err != nil {
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{
+					Error:        err.Error(),
+					Rule:         rule.GetName(),
+					Action:       action.GetName(),
+					OutputTarget: output.GetTarget(),
+					Message:      "rules",
+				})
+				valid = false
+			}
+		}
+	}
+
+	return valid
+}

--- a/cmd/rule_validation_test.go
+++ b/cmd/rule_validation_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"testing"
+
+	ruleengine "github.com/falcosecurity/falco-talon/internal/rules"
+)
+
+func TestValidateRulesRejectsUnknownActionner(t *testing.T) {
+	rules := &[]*ruleengine.Rule{
+		{
+			Name: "test-rule",
+			Actions: []*ruleengine.Action{
+				{
+					Name:      "test-action",
+					Actionner: "tests:missing",
+				},
+			},
+		},
+	}
+
+	if validateRules(rules) {
+		t.Fatal("expected validation to reject unknown actionners")
+	}
+}
+
+func TestValidateRulesRejectsUnknownOutputTarget(t *testing.T) {
+	rules := &[]*ruleengine.Rule{
+		{
+			Name: "test-rule",
+			Actions: []*ruleengine.Action{
+				{
+					Name:      "capture-file",
+					Actionner: "kubernetes:download",
+					Parameters: map[string]any{
+						"file": "/tmp/demo.log",
+					},
+					Output: ruleengine.Output{
+						Target: "tests:missing",
+						Parameters: map[string]any{
+							"destination": "/tmp",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if validateRules(rules) {
+		t.Fatal("expected validation to reject unknown output targets")
+	}
+}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -3,10 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/falcosecurity/falco-talon/actionners"
 	"github.com/falcosecurity/falco-talon/configuration"
 	ruleengine "github.com/falcosecurity/falco-talon/internal/rules"
-	"github.com/falcosecurity/falco-talon/outputs"
 	"github.com/falcosecurity/falco-talon/utils"
 
 	"github.com/jinzhu/copier"
@@ -36,54 +34,7 @@ var rulesChecksCmd = &cobra.Command{
 		if rules == nil {
 			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
 		}
-		defaultActionners := actionners.ListDefaultActionners()
-		defaultOutputs := outputs.ListDefaultOutputs()
-
-		valid := true
-		if rules != nil {
-			for _, i := range *rules {
-				for _, j := range i.GetActions() {
-					actionner := defaultActionners.FindActionner(j.GetActionner())
-					if actionner == nil {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "unknown actionner", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-						valid = false
-						continue
-					}
-					if err := actionner.CheckParameters(j); err != nil {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-						valid = false
-					}
-					o := j.GetOutput()
-					if o == nil && actionner.Information().RequireOutput {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "an output is required", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-						valid = false
-					}
-					if actionner != nil {
-						o := j.GetOutput()
-						if o == nil && actionner.Information().RequireOutput {
-							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "an output is required", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-							valid = false
-						}
-						if o != nil {
-							output := defaultOutputs.FindOutput(o.GetTarget())
-							if output == nil {
-								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "unknown target", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-								valid = false
-							} else if len(o.Parameters) == 0 {
-								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing parameters for the output", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-								valid = false
-							} else {
-								if err := output.CheckParameters(o); err != nil {
-									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-									valid = false
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		if !valid {
+		if !validateRules(rules) {
 			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
 		}
 		utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "rules file valid", Message: "rules"})

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,49 +43,7 @@ var serverCmd = &cobra.Command{
 			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
 		}
 
-		defaultActionners := actionners.ListDefaultActionners()
-		defaultOutputs := outputs.ListDefaultOutputs()
-
-		valid := true
-		if rules != nil {
-			for _, i := range *rules {
-				for _, j := range i.GetActions() {
-					actionner := defaultActionners.FindActionner(j.GetActionner())
-					if actionner == nil {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "unknown actionner", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-						valid = false
-					} else {
-						if err := actionner.CheckParameters(j); err != nil {
-							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-							valid = false
-						}
-					}
-					if actionner != nil {
-						o := j.GetOutput()
-						if o == nil && actionner.Information().RequireOutput {
-							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "an output is required", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-							valid = false
-						}
-						if o != nil {
-							output := defaultOutputs.FindOutput(o.GetTarget())
-							if output == nil {
-								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "unknown target", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-								valid = false
-							} else if len(o.Parameters) == 0 {
-								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing parameters for the output", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-								valid = false
-							} else {
-								if err := output.CheckParameters(o); err != nil {
-									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-									valid = false
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		if !valid {
+		if !validateRules(rules) {
 			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
 		}
 
@@ -148,53 +106,16 @@ var serverCmd = &cobra.Command{
 								break
 							}
 
-							defaultActionners := actionners.ListDefaultActionners()
-							defaultOutputs := outputs.ListDefaultOutputs()
-
 							if newRules != nil {
-								valid := true
-								for _, i := range *newRules {
-									for _, j := range i.GetActions() {
-										actionner := defaultActionners.FindActionner(j.GetActionner())
-										if actionner == nil {
-											break
-										}
-										if err := actionner.CheckParameters(j); err != nil {
-											utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Message: "rules"})
-											valid = false
-										}
-										o := j.GetOutput()
-										if o == nil && actionner.Information().RequireOutput {
-											utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "an output is required", Rule: i.GetName(), Action: j.GetName(), Actionner: j.GetActionner(), Message: "rules"})
-											valid = false
-										}
-										if o != nil {
-											output := defaultOutputs.FindOutput(o.GetTarget())
-											if output == nil {
-												utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "unknown target", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-												valid = false
-											}
-											if len(o.Parameters) == 0 {
-												utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing parameters for the output", Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-												valid = false
-											}
-											if err := output.CheckParameters(o); err != nil {
-												utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Rule: i.GetName(), Action: j.GetName(), OutputTarget: o.GetTarget(), Message: "rules"})
-												valid = false
-											}
-										}
-									}
-
-									if !valid {
-										utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
-										break
-									}
-									utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rules have been successfully loaded", len(*rules)), Message: "rules"})
-									rules = newRules
-									if err := actionners.Init(); err != nil {
-										utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "actionners"})
-										break
-									}
+								if !validateRules(newRules) {
+									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+									break
+								}
+								utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rules have been successfully loaded", len(*newRules)), Message: "rules"})
+								rules = newRules
+								if err := actionners.Init(); err != nil {
+									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "actionners"})
+									break
 								}
 							}
 						}


### PR DESCRIPTION
/kind bug
/area rule-engine

**What this PR does / Why we need it**:

`watch_rules` reload was validating rules with a different path than startup and `rules check`.
That made reload a bit wonky. A bad `output.target` could panic, and an unknown actionner was not rejected cleanly.
This patch reuses one validator for all 3 paths, so bad reloads get refused and the current rules stay in place.

**How to reproduce the issue**:

1. Start Talon with `watch_rules: true`. This is the default in `config_example.yaml`.
2. Use a watched rules file with a valid `kubernetes:download` action.
3. Edit that action and save this:

```yaml
output:
  target: tests:missing
  parameters:
    destination: /tmp
```

4. Before this patch, the reload path can blow up here because it calls `CheckParameters` on a nil output impl.
5. After this patch, Talon logs `invalid rules` and keeps running with the previous rules. nice and clean.

You can also see the guard with `go test ./cmd`.

**Which issue(s) this PR fixes**:

N/A, I didnt find a matching issue.

**Special notes for your reviewer**:

Small fix, plus regression tests.
