### PR TITLE
fix: avoid panic when action overrides add output parameters

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -277,6 +277,12 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 				if l.IgnoreErrors != "" {
 					i.IgnoreErrors = l.IgnoreErrors
 				}
+				if i.Output.Target == "" && l.Output.Target != "" {
+					i.Output.Target = l.Output.Target
+				}
+				if i.Output.Parameters == nil && len(l.Output.Parameters) != 0 {
+					i.Output.Parameters = make(map[string]any)
+				}
 				if i.Parameters == nil && len(l.Parameters) != 0 {
 					i.Parameters = make(map[string]any)
 				}

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -42,3 +42,58 @@ func TestExtractActionsRulesReportsTheBrokenFileName(t *testing.T) {
 		t.Fatalf("expected error to mention %q, got %q", brokenRulesFile, err.Error())
 	}
 }
+
+func TestExtractActionsRulesMergesOutputParametersIntoActionsWithoutPanicking(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	baseRulesFile := filepath.Join(tmpDir, "base-rules.yaml")
+	if err := os.WriteFile(baseRulesFile, []byte(`
+- action: Capture logs
+  actionner: kubernetes:log
+`), 0o600); err != nil {
+		t.Fatalf("write base rules file: %v", err)
+	}
+
+	overrideRulesFile := filepath.Join(tmpDir, "override-rules.yaml")
+	if err := os.WriteFile(overrideRulesFile, []byte(`
+- action: Capture logs
+  output:
+    target: aws:s3
+    parameters:
+      bucket: base-bucket
+
+- rule: Repro
+  match:
+    rules:
+      - Test
+  actions:
+    - action: Capture logs
+  notifiers: []
+`), 0o600); err != nil {
+		t.Fatalf("write override rules file: %v", err)
+	}
+
+	actions, rules, err := extractActionsRules([]string{baseRulesFile, overrideRulesFile})
+	if err != nil {
+		t.Fatalf("extract rules: %v", err)
+	}
+
+	if len(*actions) != 1 {
+		t.Fatalf("expected 1 merged action, got %d", len(*actions))
+	}
+
+	action := (*actions)[0]
+	if action.Output.Target != "aws:s3" {
+		t.Fatalf("expected merged output target %q, got %q", "aws:s3", action.Output.Target)
+	}
+
+	if got := action.Output.Parameters["bucket"]; got != "base-bucket" {
+		t.Fatalf("expected merged output bucket %q, got %#v", "base-bucket", got)
+	}
+
+	if len(*rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(*rules))
+	}
+}


### PR DESCRIPTION
/kind bug
/area rule-engine

**What this PR does / Why we need it**:

`rules check` can panic when an action is defined in one rules file and its `output.parameters` are added from another one. That's a real split-rules workflow, so its pretty easy to hit. This just initializes the output map before merge, so no boom.

**How to reproduce the issue**:

1. Create `base.yaml`:
```yaml
- action: Capture logs
  actionner: kubernetes:log
```
2. Create `override.yaml`:
```yaml
- action: Capture logs
  output:
    target: aws:s3
    parameters:
      bucket: base-bucket

- rule: Repro
  match:
    rules:
      - Test
  actions:
    - action: Capture logs
  notifiers: []
```
3. Run `go run . rules check -r base.yaml -r override.yaml`
4. On `main` it panics with `assignment to entry in nil map`
5. With this patch it prints `rules file valid`

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Added a regression test. No cloud or provider limits here, this is just local rule parsing with 2 valid YAML files.
