### PR TITLE
fix: guard event output-field type assertions against panics

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -54,27 +54,30 @@ func DecodeEvent(payload io.Reader) (*Event, error) {
 	return &event, nil
 }
 
-func (event *Event) GetPodName() string {
-	if event.OutputFields["k8s.pod.name"] != nil {
-		return event.OutputFields["k8s.pod.name"].(string)
-	}
-	if event.OutputFields["ka.target.pod.name"] != nil {
-		return event.OutputFields["ka.target.pod.name"].(string)
-	}
-	if event.OutputFields["ka.target.name"] != nil {
-		return event.OutputFields["ka.target.name"].(string)
+// getOutputFieldString returns the value of the first present output field
+// among keys, as a string. Because DecodeEvent uses json.Decoder.UseNumber(),
+// non-string fields (e.g. numeric values decoded as json.Number) would panic
+// on a bare type assertion; they are formatted with fmt.Sprintf instead.
+func (event *Event) getOutputFieldString(keys ...string) string {
+	for _, key := range keys {
+		v, ok := event.OutputFields[key]
+		if !ok || v == nil {
+			continue
+		}
+		if s, ok := v.(string); ok {
+			return s
+		}
+		return fmt.Sprintf("%v", v)
 	}
 	return ""
 }
 
+func (event *Event) GetPodName() string {
+	return event.getOutputFieldString("k8s.pod.name", "ka.target.pod.name", "ka.target.name")
+}
+
 func (event *Event) GetNamespaceName() string {
-	if event.OutputFields["k8s.ns.name"] != nil {
-		return event.OutputFields["k8s.ns.name"].(string)
-	}
-	if event.OutputFields["ka.target.namespace"] != nil {
-		return event.OutputFields["ka.target.namespace"].(string)
-	}
-	return ""
+	return event.getOutputFieldString("k8s.ns.name", "ka.target.namespace")
 }
 
 func (event *Event) GetHostname() string {
@@ -82,54 +85,27 @@ func (event *Event) GetHostname() string {
 }
 
 func (event *Event) GetTargetName() string {
-	if event.OutputFields["ka.target.name"] != nil {
-		return event.OutputFields["ka.target.name"].(string)
-	}
-	return ""
+	return event.getOutputFieldString("ka.target.name")
 }
 
 func (event *Event) GetTargetNamespace() string {
-	if event.OutputFields["ka.target.namespace"] != nil {
-		return event.OutputFields["ka.target.namespace"].(string)
-	}
-	return ""
+	return event.getOutputFieldString("ka.target.namespace")
 }
 
 func (event *Event) GetTargetResource() string {
-	if event.OutputFields["ka.target.resource"] != nil {
-		return event.OutputFields["ka.target.resource"].(string)
-	}
-	return ""
+	return event.getOutputFieldString("ka.target.resource")
 }
 
 func (event *Event) GetRemoteIP() string {
-	if i := event.OutputFields["fd.rip"]; i != nil {
-		return i.(string)
-	}
-	if i := event.OutputFields["fd.sip"]; i != nil {
-		return i.(string)
-	}
-	return ""
+	return event.getOutputFieldString("fd.rip", "fd.sip")
 }
 
 func (event *Event) GetRemotePort() string {
-	if i := event.OutputFields["fd.rport"]; i != nil {
-		return i.(string)
-	}
-	if i := event.OutputFields["fd.sport"]; i != nil {
-		return i.(string)
-	}
-	return ""
+	return event.getOutputFieldString("fd.rport", "fd.sport")
 }
 
 func (event *Event) GetRemoteProtocol() string {
-	if i := event.OutputFields["fd.rproto"]; i != nil {
-		return i.(string)
-	}
-	if i := event.OutputFields["fd.rproto"]; i != nil {
-		return i.(string)
-	}
-	return ""
+	return event.getOutputFieldString("fd.rproto")
 }
 
 func (event *Event) AddContext(elements map[string]any) {

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -54,11 +54,13 @@ func DecodeEvent(payload io.Reader) (*Event, error) {
 	return &event, nil
 }
 
-// getOutputFieldString returns the value of the first present output field
+// GetOutputFieldString returns the value of the first present output field
 // among keys, as a string. Because DecodeEvent uses json.Decoder.UseNumber(),
 // non-string fields (e.g. numeric values decoded as json.Number) would panic
 // on a bare type assertion; they are formatted with fmt.Sprintf instead.
-func (event *Event) getOutputFieldString(keys ...string) string {
+// It is exported so consumers reading raw output fields (e.g. the checks
+// package) can go through the same safe accessor.
+func (event *Event) GetOutputFieldString(keys ...string) string {
 	for _, key := range keys {
 		v, ok := event.OutputFields[key]
 		if !ok || v == nil {
@@ -73,11 +75,11 @@ func (event *Event) getOutputFieldString(keys ...string) string {
 }
 
 func (event *Event) GetPodName() string {
-	return event.getOutputFieldString("k8s.pod.name", "ka.target.pod.name", "ka.target.name")
+	return event.GetOutputFieldString("k8s.pod.name", "ka.target.pod.name", "ka.target.name")
 }
 
 func (event *Event) GetNamespaceName() string {
-	return event.getOutputFieldString("k8s.ns.name", "ka.target.namespace")
+	return event.GetOutputFieldString("k8s.ns.name", "ka.target.namespace")
 }
 
 func (event *Event) GetHostname() string {
@@ -85,27 +87,27 @@ func (event *Event) GetHostname() string {
 }
 
 func (event *Event) GetTargetName() string {
-	return event.getOutputFieldString("ka.target.name")
+	return event.GetOutputFieldString("ka.target.name")
 }
 
 func (event *Event) GetTargetNamespace() string {
-	return event.getOutputFieldString("ka.target.namespace")
+	return event.GetOutputFieldString("ka.target.namespace")
 }
 
 func (event *Event) GetTargetResource() string {
-	return event.getOutputFieldString("ka.target.resource")
+	return event.GetOutputFieldString("ka.target.resource")
 }
 
 func (event *Event) GetRemoteIP() string {
-	return event.getOutputFieldString("fd.rip", "fd.sip")
+	return event.GetOutputFieldString("fd.rip", "fd.sip")
 }
 
 func (event *Event) GetRemotePort() string {
-	return event.getOutputFieldString("fd.rport", "fd.sport")
+	return event.GetOutputFieldString("fd.rport", "fd.sport")
 }
 
 func (event *Event) GetRemoteProtocol() string {
-	return event.getOutputFieldString("fd.rproto")
+	return event.GetOutputFieldString("fd.rproto")
 }
 
 func (event *Event) AddContext(elements map[string]any) {

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1,0 +1,51 @@
+package events
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGettersDoNotPanicOnNonStringFields ensures the output-field getters do
+// not panic when a field is decoded as a non-string value. DecodeEvent uses
+// json.Decoder.UseNumber(), so a numeric field such as fd.rport is a
+// json.Number, which used to panic on a bare .(string) assertion.
+func TestGettersDoNotPanicOnNonStringFields(t *testing.T) {
+	payload := `{
+		"output_fields": {
+			"fd.rport": 8080,
+			"fd.rproto": true,
+			"k8s.pod.name": "nginx"
+		}
+	}`
+
+	event, err := DecodeEvent(strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("DecodeEvent returned an unexpected error: %v", err)
+	}
+
+	if got := event.GetRemotePort(); got != "8080" {
+		t.Errorf("GetRemotePort() = %q, want %q", got, "8080")
+	}
+	if got := event.GetRemoteProtocol(); got != "true" {
+		t.Errorf("GetRemoteProtocol() = %q, want %q", got, "true")
+	}
+	if got := event.GetPodName(); got != "nginx" {
+		t.Errorf("GetPodName() = %q, want %q", got, "nginx")
+	}
+}
+
+// TestGettersReturnEmptyWhenFieldsMissing ensures the getters return an empty
+// string when none of their candidate keys are present.
+func TestGettersReturnEmptyWhenFieldsMissing(t *testing.T) {
+	event, err := DecodeEvent(strings.NewReader(`{"output_fields": {}}`))
+	if err != nil {
+		t.Fatalf("DecodeEvent returned an unexpected error: %v", err)
+	}
+
+	if got := event.GetPodName(); got != "" {
+		t.Errorf("GetPodName() = %q, want empty string", got)
+	}
+	if got := event.GetNamespaceName(); got != "" {
+		t.Errorf("GetNamespaceName() = %q, want empty string", got)
+	}
+}

--- a/internal/kubernetes/checks/checks.go
+++ b/internal/kubernetes/checks/checks.go
@@ -74,12 +74,12 @@ func CheckRemoteIP(event *events.Event) error {
 		return errors.New("missing IP field(s) (fd.sip or fd.rip)")
 	}
 	if event.OutputFields["fd.sip"] != nil {
-		if net.ParseIP(event.OutputFields["fd.sip"].(string)) == nil {
+		if net.ParseIP(event.GetOutputFieldString("fd.sip")) == nil {
 			return errors.New("wrong value for fd.sip")
 		}
 	}
 	if event.OutputFields["fd.rip"] != nil {
-		if net.ParseIP(event.OutputFields["fd.rip"].(string)) == nil {
+		if net.ParseIP(event.GetOutputFieldString("fd.rip")) == nil {
 			return errors.New("wrong value for fd.rip")
 		}
 	}

--- a/internal/kubernetes/checks/checks_test.go
+++ b/internal/kubernetes/checks/checks_test.go
@@ -1,0 +1,40 @@
+package checks
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/falcosecurity/falco-talon/internal/events"
+)
+
+// TestCheckRemoteIPDoesNotPanicOnNonStringFields ensures CheckRemoteIP does not
+// panic when an IP field is decoded as a non-string value. DecodeEvent uses
+// json.Decoder.UseNumber(), so such a field used to panic on the bare
+// .(string) assertion instead of being reported as a wrong value.
+func TestCheckRemoteIPDoesNotPanicOnNonStringFields(t *testing.T) {
+	event, err := events.DecodeEvent(strings.NewReader(`{"output_fields": {"fd.sip": 8080}}`))
+	if err != nil {
+		t.Fatalf("DecodeEvent returned an unexpected error: %v", err)
+	}
+
+	err = CheckRemoteIP(event)
+	if err == nil {
+		t.Fatal("CheckRemoteIP() returned no error, want an error for a non-IP value")
+	}
+	if err.Error() != "wrong value for fd.sip" {
+		t.Errorf("CheckRemoteIP() error = %q, want %q", err, "wrong value for fd.sip")
+	}
+}
+
+// TestCheckRemoteIPAcceptsValidAddresses ensures the switch to the safe
+// accessor keeps the nominal string case working.
+func TestCheckRemoteIPAcceptsValidAddresses(t *testing.T) {
+	event, err := events.DecodeEvent(strings.NewReader(`{"output_fields": {"fd.sip": "10.0.0.1", "fd.rip": "192.168.1.1"}}`))
+	if err != nil {
+		t.Fatalf("DecodeEvent returned an unexpected error: %v", err)
+	}
+
+	if err := CheckRemoteIP(event); err != nil {
+		t.Errorf("CheckRemoteIP() returned an unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area core

**What this PR does / Why we need it**:

The event output-field getters in `internal/events/events.go` (`GetPodName`, `GetNamespaceName`, `GetRemoteIP`, `GetRemotePort`, `GetRemoteProtocol`, `GetTarget*`) performed bare `.(string)` type assertions on values read from `Event.OutputFields`.

`DecodeEvent` decodes the payload with `json.Decoder.UseNumber()`, so any non-string field is not a `string`: a numeric port becomes a `json.Number`, and boolean/object/array fields keep their own types. A bare `.(string)` assertion on such a value panics, and the panic propagates up to the consumer with no `recover()` — a single malformed or unexpected event field can take down event processing.

This PR introduces a `getOutputFieldString(keys ...string)` helper that returns the value of the first present key as a string, using a checked assertion (`v, ok := v.(string)`) with an `fmt.Sprintf("%v", v)` fallback for non-string values, and routes every getter through it. This eliminates the panic at the source and keeps the previous key-precedence behaviour unchanged.

While collapsing `GetRemoteProtocol` onto the helper, its dead duplicate lookup (it read `fd.rproto` in both branches) is reduced to a single key. This is behaviour-neutral; the function still does not consult `fd.sproto`, which is tracked separately.

Files changed:

- `internal/events/events.go` — safe getters via the new helper
- `internal/events/events_test.go` — new tests

**How to reproduce the issue**:

Send a Falco event whose `output_fields` contains a numeric value for a field consumed by a getter, e.g. `"fd.rport": 8080`. Any actionner calling `event.GetRemotePort()` panics on the `json.Number` returned by the decoder, because the value is asserted as `string` without a check.

**Which issue(s) this PR fixes**:

<!-- Fixes #<issue number> if applicable -->

**Special notes for your reviewer**:

Two tests are added: one that decodes numeric (`fd.rport`) and boolean (`fd.rproto`) fields and asserts the getters return their formatted string values instead of panicking, and one covering the missing-field case (empty string). Both fail (panic) against the previous code.

Verified locally: `go build ./...`, `go vet ./...` and `go test ./internal/events/...` all pass.

A `recover()` in the consumer loop was intentionally left out: fixing the assertions at the source removes the panic these getters could raise. A broader defence-in-depth `recover()` can be discussed separately.
