### PR TITLE
fix: fall back to fd.sproto in GetRemoteProtocol

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -126,7 +126,7 @@ func (event *Event) GetRemoteProtocol() string {
 	if i := event.OutputFields["fd.rproto"]; i != nil {
 		return i.(string)
 	}
-	if i := event.OutputFields["fd.rproto"]; i != nil {
+	if i := event.OutputFields["fd.sproto"]; i != nil {
 		return i.(string)
 	}
 	return ""


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area core

**What this PR does / Why we need it**:

`GetRemoteProtocol` in `internal/events/events.go` read `fd.rproto` in both of its branches, so the fallback was a dead duplicate — the remote protocol was never resolved from `fd.sproto` when `fd.rproto` is absent. This is inconsistent with the sibling getters, which correctly fall back to their source-side field: `GetRemoteIP` uses `fd.rip` then `fd.sip`, and `GetRemotePort` uses `fd.rport` then `fd.sport`.

This PR changes the second lookup to `fd.sproto`, so the protocol is resolved from the source side when the remote side is not present.

Files changed:

- `internal/events/events.go`

**How to reproduce the issue**:

Send a Falco event whose `output_fields` carries only `fd.sproto` (no `fd.rproto`) — for example an outbound-connection event where only the source protocol field is populated. `event.GetRemoteProtocol()` returns an empty string instead of the `fd.sproto` value.

**Which issue(s) this PR fixes**:

<!-- Fixes #<issue number> if applicable -->

**Special notes for your reviewer**:

Branched from `main`. This touches the same function as the "guard event output-field type assertions" PR (`fix/event-field-type-assertions`); depending on merge order there may be a trivial conflict on this function, easily resolved. This PR keeps the change minimal (the field name only) and does not include the type-assertion hardening from the other PR.

Verified locally: `go build ./...` and `go vet ./internal/events/...` pass.
