### PR TITLE
refactor: extract shared BuildObjectKey helper for outputs

### DIFF
--- a/outputs/aws/s3/s3.go
+++ b/outputs/aws/s3/s3.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -14,6 +13,7 @@ import (
 	aws "github.com/falcosecurity/falco-talon/internal/aws/client"
 	"github.com/falcosecurity/falco-talon/internal/models"
 	"github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/outputs/helpers"
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
@@ -101,21 +101,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	parameters.Prefix = strings.TrimSuffix(parameters.Prefix, "/")
 	parameters.Prefix = strings.TrimPrefix(parameters.Prefix, "/") + "/"
 
-	var key string
-	switch {
-	case data.Objects["namespace"] != "" && data.Objects["pod"] != "":
-		key = fmt.Sprintf("%v_%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["namespace"], data.Objects["pod"], strings.ReplaceAll(data.Name, "/", "_"))
-	case data.Objects["hostname"] != "":
-		key = fmt.Sprintf("%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["hostname"], strings.ReplaceAll(data.Name, "/", "_"))
-	default:
-		var s string
-		for i, j := range data.Objects {
-			if i != fileStr {
-				s += j + "_"
-			}
-		}
-		key = fmt.Sprintf("%v_%v%v", time.Now().Format("2006-01-02T15-04-05Z"), s, strings.ReplaceAll(data.Name, "/", "_"))
-	}
+	key := helpers.BuildObjectKey(data)
 
 	var region string
 	awsClient := aws.GetAWSClient()

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -5,10 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/falcosecurity/falco-talon/internal/models"
 	"github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/outputs/helpers"
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
@@ -82,21 +82,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 		}, err
 	}
 
-	var key string
-	switch {
-	case data.Objects["namespace"] != "" && data.Objects["pod"] != "":
-		key = fmt.Sprintf("%v_%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["namespace"], data.Objects["pod"], strings.ReplaceAll(data.Name, "/", "_"))
-	case data.Objects["hostname"] != "":
-		key = fmt.Sprintf("%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["hostname"], strings.ReplaceAll(data.Name, "/", "_"))
-	default:
-		var s string
-		for i, j := range data.Objects {
-			if i != Name {
-				s += j + "_"
-			}
-		}
-		key = fmt.Sprintf("%v_%v%v", time.Now().Format("2006-01-02T15-04-05Z"), s, strings.ReplaceAll(data.Name, "/", "_"))
-	}
+	key := helpers.BuildObjectKey(data)
 
 	dstfile := fmt.Sprintf("%v/%v", strings.TrimSuffix(parameters.Destination, "/"), key)
 

--- a/outputs/gcs/gcs.go
+++ b/outputs/gcs/gcs.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/falcosecurity/falco-talon/internal/gcp/client"
 	"github.com/falcosecurity/falco-talon/internal/models"
 	"github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/outputs/helpers"
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
@@ -123,21 +123,7 @@ func (o Output) RunWithClient(client client.GcpGcsAPI, output *rules.Output, dat
 		parameters.Prefix += "/"
 	}
 
-	var key string
-	switch {
-	case data.Objects["namespace"] != "" && data.Objects["pod"] != "":
-		key = fmt.Sprintf("%v_%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["namespace"], data.Objects["pod"], strings.ReplaceAll(data.Name, "/", "_"))
-	case data.Objects["hostname"] != "":
-		key = fmt.Sprintf("%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["hostname"], strings.ReplaceAll(data.Name, "/", "_"))
-	default:
-		var s string
-		for i, j := range data.Objects {
-			if i != fileStr {
-				s += j + "_"
-			}
-		}
-		key = fmt.Sprintf("%v_%v%v", time.Now().Format("2006-01-02T15-04-05Z"), s, strings.ReplaceAll(data.Name, "/", "_"))
-	}
+	key := helpers.BuildObjectKey(data)
 
 	objects := map[string]string{
 		fileStr:  data.Name,

--- a/outputs/helpers/helpers.go
+++ b/outputs/helpers/helpers.go
@@ -1,0 +1,47 @@
+package helpers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/falcosecurity/falco-talon/internal/models"
+)
+
+const (
+	keyTimestampLayout = "2006-01-02T15-04-05Z"
+	fileObjectKey      = "file"
+)
+
+// BuildObjectKey returns a timestamped, filesystem-safe key used by the outputs
+// (file, S3, GCS, MinIO) to store the artifact carried by data. The key is
+// prefixed with the current time and derived from the well-known objects
+// (namespace/pod, then hostname); otherwise it falls back to every object
+// value except "file", in a deterministic (sorted) order.
+func BuildObjectKey(data *models.Data) string {
+	timestamp := time.Now().Format(keyTimestampLayout)
+	name := strings.ReplaceAll(data.Name, "/", "_")
+
+	switch {
+	case data.Objects["namespace"] != "" && data.Objects["pod"] != "":
+		return fmt.Sprintf("%v_%v_%v_%v", timestamp, data.Objects["namespace"], data.Objects["pod"], name)
+	case data.Objects["hostname"] != "":
+		return fmt.Sprintf("%v_%v_%v", timestamp, data.Objects["hostname"], name)
+	default:
+		keys := make([]string, 0, len(data.Objects))
+		for k := range data.Objects {
+			if k != fileObjectKey {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+
+		var builder strings.Builder
+		for _, k := range keys {
+			builder.WriteString(data.Objects[k])
+			builder.WriteString("_")
+		}
+		return fmt.Sprintf("%v_%v%v", timestamp, builder.String(), name)
+	}
+}

--- a/outputs/helpers/helpers_test.go
+++ b/outputs/helpers/helpers_test.go
@@ -1,0 +1,51 @@
+package helpers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/falcosecurity/falco-talon/internal/models"
+)
+
+func TestBuildObjectKey(t *testing.T) {
+	t.Run("namespace and pod", func(t *testing.T) {
+		key := BuildObjectKey(&models.Data{
+			Name:    "logs/app.txt",
+			Objects: map[string]string{"namespace": "prod", "pod": "nginx"},
+		})
+		// timestamp_namespace_pod_name, with "/" replaced by "_" in the name
+		if !strings.HasSuffix(key, "_prod_nginx_logs_app.txt") {
+			t.Errorf("unexpected key: %q", key)
+		}
+	})
+
+	t.Run("hostname", func(t *testing.T) {
+		key := BuildObjectKey(&models.Data{
+			Name:    "capture.pcap",
+			Objects: map[string]string{"hostname": "node-1"},
+		})
+		if !strings.HasSuffix(key, "_node-1_capture.pcap") {
+			t.Errorf("unexpected key: %q", key)
+		}
+	})
+
+	t.Run("default is deterministic and sorted, excluding file", func(t *testing.T) {
+		objects := map[string]string{"zeta": "z", "alpha": "a", "file": "ignored"}
+		first := BuildObjectKey(&models.Data{Name: "n", Objects: objects})
+		second := BuildObjectKey(&models.Data{Name: "n", Objects: objects})
+
+		// keys are sorted (alpha before zeta) and "file" is excluded
+		if !strings.Contains(first, "_a_z_") {
+			t.Errorf("expected sorted values a then z, got: %q", first)
+		}
+		if strings.Contains(first, "ignored") {
+			t.Errorf("the \"file\" object must be excluded, got: %q", first)
+		}
+		// deterministic: the value part (everything after the timestamp) is stable
+		_, firstValues, _ := strings.Cut(first, "_")
+		_, secondValues, _ := strings.Cut(second, "_")
+		if firstValues != secondValues {
+			t.Errorf("key value part is not deterministic: %q vs %q", first, second)
+		}
+	})
+}

--- a/outputs/minio/minio.go
+++ b/outputs/minio/minio.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	miniosdk "github.com/minio/minio-go/v7"
 
 	minio "github.com/falcosecurity/falco-talon/internal/minio/client"
 	"github.com/falcosecurity/falco-talon/internal/models"
 	"github.com/falcosecurity/falco-talon/internal/rules"
+	"github.com/falcosecurity/falco-talon/outputs/helpers"
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
@@ -100,21 +100,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 
 	parameters.Prefix = strings.TrimSuffix(parameters.Prefix, "/") + "/"
 
-	var key string
-	switch {
-	case data.Objects["namespace"] != "" && data.Objects["pod"] != "":
-		key = fmt.Sprintf("%v_%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["namespace"], data.Objects["pod"], strings.ReplaceAll(data.Name, "/", "_"))
-	case data.Objects["hostname"] != "":
-		key = fmt.Sprintf("%v_%v_%v", time.Now().Format("2006-01-02T15-04-05Z"), data.Objects["hostname"], strings.ReplaceAll(data.Name, "/", "_"))
-	default:
-		var s string
-		for i, j := range data.Objects {
-			if i != fileStr {
-				s += j + "_"
-			}
-		}
-		key = fmt.Sprintf("%v_%v%v", time.Now().Format("2006-01-02T15-04-05Z"), s, strings.ReplaceAll(data.Name, "/", "_"))
-	}
+	key := helpers.BuildObjectKey(data)
 
 	objects := map[string]string{
 		fileStr:  data.Name,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Any specific area of the project related to this PR?**

/area ouputs

**What this PR does / Why we need it**:

The `file`, `aws/s3`, `gcs` and `minio` outputs each carried an identical ~15-line block that builds the storage key from the event data (a timestamp, then `namespace`/`pod`, then `hostname`, then a fallback over the remaining objects). This PR extracts that logic into a single `outputs/helpers.BuildObjectKey(*models.Data)` and routes the four outputs through it.

The helper lives in a dedicated leaf package `outputs/helpers` rather than in the `outputs` package, because `outputs` imports every sub-output for registration — a sub-output importing `outputs` would create an import cycle.

Two behavioural notes:

- The fallback branch (`default`) now sorts the object keys before concatenating their values. Previously it ranged over the map directly, so the generated key depended on Go's randomized map iteration order and was not stable between calls for the same data. It is now deterministic.
- The timestamp is computed once per key instead of two or three times across separate `fmt.Sprintf` calls, so a single key can no longer straddle a second boundary.

The `namespace`/`pod` and `hostname` cases are unchanged.

Files changed:

- `outputs/helpers/helpers.go` — new `BuildObjectKey` helper
- `outputs/helpers/helpers_test.go` — new unit tests
- `outputs/aws/s3/s3.go`, `outputs/minio/minio.go`, `outputs/gcs/gcs.go`, `outputs/file/file.go` — use the helper (removed the duplicated block and the now-unused `time` import)

**How to reproduce the issue**:

Not a user-facing bug; this is a de-duplication refactor. The only behaviour change is that the fallback key (used when neither `namespace`+`pod` nor `hostname` are present) is now deterministic instead of depending on map iteration order.

**Which issue(s) this PR fixes**:

<!-- Fixes #<issue number> if applicable -->

**Special notes for your reviewer**:

Net change is -64/+8 lines across the four outputs plus the new shared package. Unit tests cover the three branches (namespace/pod, hostname, sorted fallback with the `file` object excluded) and assert the fallback key is deterministic.

Verified locally: `go build ./...`, `go vet ./outputs/...` and `go test ./outputs/...` all pass.
