### PR TITLE
fix: use daemonset lookup for delete target checks

### DIFF
--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -43,6 +43,20 @@ type Client struct {
 	RestConfig *rest.Config
 }
 
+type targetLookup interface {
+	GetNamespace(name string) (*corev1.Namespace, error)
+	GetConfigMap(name, namespace string) (*corev1.ConfigMap, error)
+	GetSecret(name, namespace string) (*corev1.Secret, error)
+	GetDeployment(name, namespace string) (*appsv1.Deployment, error)
+	GetDaemonSet(name, namespace string) (*appsv1.DaemonSet, error)
+	GetStatefulSet(name, namespace string) (*appsv1.StatefulSet, error)
+	GetReplicaSet(name, namespace string) (*appsv1.ReplicaSet, error)
+	GetService(name, namespace string) (*corev1.Service, error)
+	GetServiceAccount(name, namespace string) (*corev1.ServiceAccount, error)
+	GetRole(name, namespace string) (*rbacv1.Role, error)
+	GetClusterRole(name, namespace string) (*rbacv1.ClusterRole, error)
+}
+
 // need to be renamed to Client
 // all the actionners need to depend on this interface so we can rename it to Client
 // without generating errors
@@ -265,6 +279,10 @@ func (client Client) GetNodeFromPod(pod *corev1.Pod) (*corev1.Node, error) {
 }
 
 func (client Client) GetTarget(resource, name, namespace string) (any, error) {
+	return lookupTarget(client, resource, name, namespace)
+}
+
+func lookupTarget(client targetLookup, resource, name, namespace string) (any, error) {
 	switch resource {
 	case "namespaces":
 		return client.GetNamespace(name)
@@ -275,7 +293,7 @@ func (client Client) GetTarget(resource, name, namespace string) (any, error) {
 	case "deployments":
 		return client.GetDeployment(name, namespace)
 	case "daemonsets":
-		return client.GetDeployment(name, namespace)
+		return client.GetDaemonSet(name, namespace)
 	case "statefulsets":
 		return client.GetStatefulSet(name, namespace)
 	case "replicasets":

--- a/internal/kubernetes/client/client_test.go
+++ b/internal/kubernetes/client/client_test.go
@@ -1,0 +1,103 @@
+package kubernetes
+
+import (
+	"errors"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type targetLookupStub struct {
+	getDeploymentCalled bool
+	getDaemonSetCalled  bool
+}
+
+func (c *targetLookupStub) GetNamespace(string) (*corev1.Namespace, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetConfigMap(string, string) (*corev1.ConfigMap, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetSecret(string, string) (*corev1.Secret, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetDeployment(string, string) (*appsv1.Deployment, error) {
+	c.getDeploymentCalled = true
+	return nil, errors.New("deployment lookup should not be used")
+}
+
+func (c *targetLookupStub) GetDaemonSet(string, string) (*appsv1.DaemonSet, error) {
+	c.getDaemonSetCalled = true
+	return &appsv1.DaemonSet{}, nil
+}
+
+func (c *targetLookupStub) GetStatefulSet(string, string) (*appsv1.StatefulSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetReplicaSet(string, string) (*appsv1.ReplicaSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetService(string, string) (*corev1.Service, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetServiceAccount(string, string) (*corev1.ServiceAccount, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetRole(string, string) (*rbacv1.Role, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (c *targetLookupStub) GetClusterRole(string, string) (*rbacv1.ClusterRole, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestLookupTargetUsesDaemonSetLookup(t *testing.T) {
+	t.Parallel()
+
+	client := &targetLookupStub{}
+
+	target, err := lookupTarget(client, "daemonsets", "falco-talon", "falco")
+	if err != nil {
+		t.Fatalf("lookup daemonset target: %v", err)
+	}
+
+	if target == nil {
+		t.Fatal("expected daemonset target to be returned")
+	}
+
+	if !client.getDaemonSetCalled {
+		t.Fatal("expected daemonset lookup to be used")
+	}
+
+	if client.getDeploymentCalled {
+		t.Fatal("did not expect deployment lookup to be used for daemonsets")
+	}
+}
+
+func TestLookupTargetKeepsDeploymentLookup(t *testing.T) {
+	t.Parallel()
+
+	client := &targetLookupStub{}
+
+	_, err := lookupTarget(client, "deployments", "falco-talon", "falco")
+	if err == nil {
+		t.Fatal("expected deployment stub error")
+	}
+
+	if !client.getDeploymentCalled {
+		t.Fatal("expected deployment lookup to be used")
+	}
+
+	if client.getDaemonSetCalled {
+		t.Fatal("did not expect daemonset lookup to be used for deployments")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area actionners
/area core

**What this PR does / Why we need it**:

`kubernetes:delete` says it can handle `daemonsets`, but the target pre-check was using the deployment getter. So a real daemonset target could get blocked before the delete action even starts. Pretty sneaky bug.

This switches the `daemonsets` lookup to `GetDaemonSet` and adds a small regression test for both the daemonset and deployment paths.

**How to reproduce the issue**:

1. Configure a `kubernetes:delete` action for a `k8s_audit` event.
2. Send an event with `ka.target.resource=daemonsets`, `ka.target.name=<existing-daemonset>`, and `ka.target.namespace=<namespace>`.
3. Before this patch, `CheckTargetExist` resolves that target through `GetDeployment`, so the action fails if there is no same named deployment.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

I rechecked the practical trigger here. This is not some edge case gated by quotas or weird limits. Any cluster that emits Kubernetes audit events and has a real `DaemonSet` can hit it.

Verified with `go test ./...`.
