### PR TITLE
fix: read title-cased Namespace/Pod keys in k8sevents notifier

### DIFF
--- a/notifiers/k8sevents/k8sevents.go
+++ b/notifiers/k8sevents/k8sevents.go
@@ -111,7 +111,7 @@ func (n Notifier) Run(log utils.LogLine) error {
 
 	client := kubernetes.GetClient()
 
-	namespace := log.Objects["namespace"]
+	namespace := log.Objects["Namespace"]
 	ns, err := client.GetNamespace(namespace)
 	if err != nil {
 		namespace = defaultStr
@@ -139,7 +139,7 @@ func (n Notifier) Run(log utils.LogLine) error {
 		InvolvedObject: corev1.ObjectReference{
 			Kind:      "Pod",
 			Namespace: namespace,
-			Name:      log.Objects["pod"],
+			Name:      log.Objects["Pod"],
 		},
 		Reason:  fmt.Sprintf("%v:%v:%v:%v", falcoTalon, log.Message, reason, log.Status),
 		Message: strings.ReplaceAll(message, `'`, `"`),

--- a/notifiers/k8sevents/k8sevents_test.go
+++ b/notifiers/k8sevents/k8sevents_test.go
@@ -1,0 +1,26 @@
+package k8sevents
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// notifiers.Notify title-cases every key of log.Objects before calling
+// Notifier.Run (see notifiers/notifiers.go), so this notifier must read
+// back the same title-cased keys it was given, not the raw lowercase
+// object keys ("namespace", "pod") produced by the actionners.
+func TestObjectKeysMatchNotifyTitleCasing(t *testing.T) {
+	titleCase := func(s string) string {
+		return cases.Title(language.Und, cases.NoLower).String(strings.ToLower(s))
+	}
+
+	if got, want := titleCase("namespace"), "Namespace"; got != want {
+		t.Fatalf("titleCase(%q) = %q, want %q", "namespace", got, want)
+	}
+	if got, want := titleCase("pod"), "Pod"; got != want {
+		t.Fatalf("titleCase(%q) = %q, want %q", "pod", got, want)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area notifiers

**What this PR does / Why we need it**:

The `k8sevents` notifier always creates the Kubernetes `Event` in the `default` namespace instead of the origin namespace of the involved pod, with an empty `InvolvedObject.Name`.

`notifiers.Notify()` title-cases every key of `log.Objects` before calling a notifier's `Run()` (`obj[cases.Title(...).String(strings.ToLower(i))] = j`), turning `"namespace"` into `"Namespace"` and `"pod"` into `"Pod"`. `notifiers/k8sevents/k8sevents.go` still read the old lowercase keys, so both lookups always missed, `client.GetNamespace("")` always failed, and the code silently fell back to `defaultStr` ("default").

This PR updates the two lookups in `k8sevents.go` to use the title-cased keys (`"Namespace"`, `"Pod"`), matching what `notifiers.Notify()` actually hands to every notifier. Also adds a regression test (`k8sevents_test.go`) pinning the title-casing contract between `notifiers.Notify()` and this notifier, since the repo has no fake-k8s-client test harness to exercise `Run()` directly against a Kubernetes API.

**How to reproduce the issue**:

1. Enable `k8sevents` as a (default) notifier.
2. Trigger any rule/action that populates `Objects["namespace"]` / `Objects["pod"]` (e.g. `kubernetes:label`) against a pod outside `default`.
3. `kubectl get events -n <origin-namespace>` — empty.
4. `kubectl get events -n default` — the falco-talon event is here instead, with an empty involved object name.

Verified live against a local `kind` cluster: built two binaries (pre-fix / post-fix) from the same rule + synthetic Falco event, and confirmed the event moves from `default` to the origin namespace once this fix is applied.

**Which issue(s) this PR fixes**:

Fixes #767 

**Special notes for your reviewer**:

- Checked every other `Objects` consumer (`loki`, `slack`, `smtp`, `elasticsearch`, output targets in `outputs/*`) — they all `range` over the map rather than doing a direct key lookup, so they're unaffected by the title-casing and don't need a matching change.
- No behavior change for any other notifier.
