### PR TITLE
fix: set InvolvedObject.uid in k8sevents notifier

### DIFF
--- a/notifiers/k8sevents/k8sevents.go
+++ b/notifiers/k8sevents/k8sevents.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	textTemplate "text/template"
 
@@ -128,6 +129,12 @@ func (n Notifier) Run(log utils.LogLine) error {
 		reason = log.OutputTarget
 	}
 
+	podName := log.Objects["Pod"]
+	var podUID types.UID
+	if pod, errGetPod := client.GetPod(podName, namespace); errGetPod == nil && pod != nil {
+		podUID = pod.UID
+	}
+
 	k8sevent := &corev1.Event{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Event",
@@ -139,7 +146,8 @@ func (n Notifier) Run(log utils.LogLine) error {
 		InvolvedObject: corev1.ObjectReference{
 			Kind:      "Pod",
 			Namespace: namespace,
-			Name:      log.Objects["Pod"],
+			Name:      podName,
+			UID:       podUID,
 		},
 		Reason:  fmt.Sprintf("%v:%v:%v:%v", falcoTalon, log.Message, reason, log.Status),
 		Message: strings.ReplaceAll(message, `'`, `"`),


### PR DESCRIPTION
## Summary

Kubernetes Events created by the `k8sevents` notifier were not showing up in the ArgoCD "Events" tab, even though they were visible via `kubectl get events`. ArgoCD requires `InvolvedObject.uid` (in addition to `name` and `namespace`) to associate an Event with a resource, and `k8sevents` never set this field.

## Changes

- `notifiers/k8sevents/k8sevents.go`:
  - Look up the involved Pod via `client.GetPod(podName, namespace)` before building the `corev1.Event`.
  - Set `InvolvedObject.UID` from the fetched Pod's `UID`.
  - If the Pod can no longer be found (e.g. already deleted), the Event is still created without a UID, preserving the previous behavior instead of failing the notification.

## Why

Fixes #769. ArgoCD needs `InvolvedObject.name`, `InvolvedObject.namespace` and `InvolvedObject.uid` to list events for a resource in its UI. Without the UID, events created by falco-talon exist in the cluster but are invisible in ArgoCD's Events tab.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./notifiers/k8sevents/...`
- [x] `go test ./notifiers/k8sevents/...`
- [ ] Manual verification: trigger a Falco rule with a `k8sevents` notifier action and confirm the resulting Event now shows up in ArgoCD's Events tab for the involved Pod.
