### PR TITLE
fix: guard OutputFields type assertions to prevent consumer crash

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -466,101 +466,118 @@ func StartConsumer(eventsC <-chan nats.MessageWithContext) {
 	config := configuration.GetConfiguration()
 	for {
 		m := <-eventsC
-		e := m.Data
-		ectx := m.Ctx
-		var event *events.Event
-		err := json.Unmarshal(e, &event)
-		if err != nil {
-			continue
+		handleEvent(config, m)
+	}
+}
+
+// handleEvent processes a single consumed event. It recovers from any panic
+// raised while handling that event (for example an unexpected type in a Falco
+// alert field) so one malformed event is logged and skipped instead of
+// terminating the process and taking the whole consumer down.
+func handleEvent(config *configuration.Configuration, m nats.MessageWithContext) {
+	defer func() {
+		if r := recover(); r != nil {
+			utils.PrintLog(utils.ErrorStr, utils.LogLine{
+				Message: "recovered from panic while processing event",
+				Error:   fmt.Sprintf("%v", r),
+			})
 		}
-		if event == nil {
-			continue
+	}()
+
+	e := m.Data
+	ectx := m.Ctx
+	var event *events.Event
+	err := json.Unmarshal(e, &event)
+	if err != nil {
+		return
+	}
+	if event == nil {
+		return
+	}
+
+	log := utils.LogLine{
+		Message:  eventStr,
+		Event:    event.Rule,
+		Priority: event.Priority,
+		Output:   event.Output,
+		Source:   event.Source,
+		TraceID:  event.TraceID,
+	}
+
+	enabledRules := rules.GetRules()
+	triggeredRules := make([]*rules.Rule, 0)
+	for _, i := range *enabledRules {
+		if i.CompareRule(event) {
+			triggeredRules = append(triggeredRules, i)
 		}
+	}
 
-		log := utils.LogLine{
-			Message:  eventStr,
-			Event:    event.Rule,
-			Priority: event.Priority,
-			Output:   event.Output,
-			Source:   event.Source,
-			TraceID:  event.TraceID,
-		}
+	if len(triggeredRules) == 0 {
+		return
+	}
 
-		enabledRules := rules.GetRules()
-		triggeredRules := make([]*rules.Rule, 0)
-		for _, i := range *enabledRules {
-			if i.CompareRule(event) {
-				triggeredRules = append(triggeredRules, i)
-			}
-		}
+	if !config.PrintAllEvents {
+		utils.PrintLog(utils.InfoStr, log)
+	}
 
-		if len(triggeredRules) == 0 {
-			continue
-		}
+	for _, i := range triggeredRules {
+		log.Message = "match"
+		log.Rule = i.GetName()
 
-		if !config.PrintAllEvents {
-			utils.PrintLog(utils.InfoStr, log)
-		}
+		tracer := traces.GetTracer()
+		mctx, span := tracer.Start(ectx, "match",
+			trace.WithAttributes(attribute.String("event.rule", event.Rule)),
+			trace.WithAttributes(attribute.String("event.output", event.Output)),
+			trace.WithAttributes(attribute.String("event.source", event.Source)),
+			trace.WithAttributes(attribute.String("event.source", event.TraceID)),
+			trace.WithAttributes(attribute.String("rule.name", i.GetName())),
+			trace.WithAttributes(attribute.String("rule.description", i.GetDescription())),
+		)
+		span.AddEvent(event.Output, trace.EventOption(trace.WithTimestamp(event.Time)))
+		span.SetStatus(codes.Ok, "match detected")
+		span.End()
 
-		for _, i := range triggeredRules {
-			log.Message = "match"
-			log.Rule = i.GetName()
+		utils.PrintLog(utils.InfoStr, log)
+		metrics.IncreaseCounter(log)
 
-			tracer := traces.GetTracer()
-			mctx, span := tracer.Start(ectx, "match",
-				trace.WithAttributes(attribute.String("event.rule", event.Rule)),
-				trace.WithAttributes(attribute.String("event.output", event.Output)),
-				trace.WithAttributes(attribute.String("event.source", event.Source)),
-				trace.WithAttributes(attribute.String("event.source", event.TraceID)),
-				trace.WithAttributes(attribute.String("rule.name", i.GetName())),
-				trace.WithAttributes(attribute.String("rule.description", i.GetDescription())),
-			)
-			span.AddEvent(event.Output, trace.EventOption(trace.WithTimestamp(event.Time)))
-			span.SetStatus(codes.Ok, "match detected")
-			span.End()
-
-			utils.PrintLog(utils.InfoStr, log)
-			metrics.IncreaseCounter(log)
-
-			for _, a := range i.GetActions() {
-				e := new(events.Event)
-				*e = *event
-				i.AddFalcoTalonContext(e, a)
-				if ListDefaultActionners().FindActionner(a.GetActionner()).Information().UseContext &&
-					len(a.GetAdditionalContexts()) != 0 {
-					for _, j := range a.GetAdditionalContexts() {
-						elements, err := talonContext.GetContext(mctx, j, e)
-						if err != nil {
-							log := utils.LogLine{
-								Message:   "context",
-								Context:   j,
-								Rule:      e.Rule,
-								Action:    a.GetName(),
-								Actionner: a.GetActionner(),
-								TraceID:   e.TraceID,
-								Error:     err.Error(),
-							}
-							utils.PrintLog(utils.ErrorStr, log)
-							if a.IgnoreErrors != trueStr {
-								break
-							}
-						} else {
-							e.AddContext(elements)
+		for _, a := range i.GetActions() {
+			e := new(events.Event)
+			*e = *event
+			i.AddFalcoTalonContext(e, a)
+			if ListDefaultActionners().FindActionner(a.GetActionner()).Information().UseContext &&
+				len(a.GetAdditionalContexts()) != 0 {
+				for _, j := range a.GetAdditionalContexts() {
+					elements, err := talonContext.GetContext(mctx, j, e)
+					if err != nil {
+						log := utils.LogLine{
+							Message:   "context",
+							Context:   j,
+							Rule:      e.Rule,
+							Action:    a.GetName(),
+							Actionner: a.GetActionner(),
+							TraceID:   e.TraceID,
+							Error:     err.Error(),
 						}
+						utils.PrintLog(utils.ErrorStr, log)
+						if a.IgnoreErrors != trueStr {
+							break
+						}
+					} else {
+						e.AddContext(elements)
 					}
 				}
-				err := runAction(mctx, i, a, e)
-				if err != nil && a.IgnoreErrors != trueStr {
-					break
-				}
-				if a.Continue == falseStr || a.Continue != trueStr && !ListDefaultActionners().FindActionner(a.GetActionner()).Information().Continue {
-					break
-				}
 			}
-
-			if i.Continue == falseStr {
+			err := runAction(mctx, i, a, e)
+			if err != nil && a.IgnoreErrors != trueStr {
 				break
 			}
+			if a.Continue == falseStr || a.Continue != trueStr && !ListDefaultActionners().FindActionner(a.GetActionner()).Information().Continue {
+				break
+			}
+		}
+
+		if i.Continue == falseStr {
+			break
 		}
 	}
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -54,25 +55,45 @@ func DecodeEvent(payload io.Reader) (*Event, error) {
 	return &event, nil
 }
 
+// outputFieldAsString returns the value stored at key in OutputFields as a
+// string. OutputFields is decoded straight from the alert JSON, so a value can
+// be any type, and Falco sends some fields (the ports) as numbers. It reports
+// false when the key is absent, nil, or holds a type with no string form, so
+// callers fall through instead of asserting on the value and panicking on a
+// non-string. Numbers arrive as json.Number (handler decode, UseNumber) or
+// float64 (consumer decode, plain json.Unmarshal); both are kept.
+func (event *Event) outputFieldAsString(key string) (string, bool) {
+	switch v := event.OutputFields[key].(type) {
+	case string:
+		return v, true
+	case json.Number:
+		return v.String(), true
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
 func (event *Event) GetPodName() string {
-	if event.OutputFields["k8s.pod.name"] != nil {
-		return event.OutputFields["k8s.pod.name"].(string)
+	if v, ok := event.outputFieldAsString("k8s.pod.name"); ok {
+		return v
 	}
-	if event.OutputFields["ka.target.pod.name"] != nil {
-		return event.OutputFields["ka.target.pod.name"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.pod.name"); ok {
+		return v
 	}
-	if event.OutputFields["ka.target.name"] != nil {
-		return event.OutputFields["ka.target.name"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.name"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetNamespaceName() string {
-	if event.OutputFields["k8s.ns.name"] != nil {
-		return event.OutputFields["k8s.ns.name"].(string)
+	if v, ok := event.outputFieldAsString("k8s.ns.name"); ok {
+		return v
 	}
-	if event.OutputFields["ka.target.namespace"] != nil {
-		return event.OutputFields["ka.target.namespace"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.namespace"); ok {
+		return v
 	}
 	return ""
 }
@@ -82,52 +103,52 @@ func (event *Event) GetHostname() string {
 }
 
 func (event *Event) GetTargetName() string {
-	if event.OutputFields["ka.target.name"] != nil {
-		return event.OutputFields["ka.target.name"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.name"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetTargetNamespace() string {
-	if event.OutputFields["ka.target.namespace"] != nil {
-		return event.OutputFields["ka.target.namespace"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.namespace"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetTargetResource() string {
-	if event.OutputFields["ka.target.resource"] != nil {
-		return event.OutputFields["ka.target.resource"].(string)
+	if v, ok := event.outputFieldAsString("ka.target.resource"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetRemoteIP() string {
-	if i := event.OutputFields["fd.rip"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.rip"); ok {
+		return v
 	}
-	if i := event.OutputFields["fd.sip"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.sip"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetRemotePort() string {
-	if i := event.OutputFields["fd.rport"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.rport"); ok {
+		return v
 	}
-	if i := event.OutputFields["fd.sport"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.sport"); ok {
+		return v
 	}
 	return ""
 }
 
 func (event *Event) GetRemoteProtocol() string {
-	if i := event.OutputFields["fd.rproto"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.rproto"); ok {
+		return v
 	}
-	if i := event.OutputFields["fd.rproto"]; i != nil {
-		return i.(string)
+	if v, ok := event.outputFieldAsString("fd.sproto"); ok {
+		return v
 	}
 	return ""
 }

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -10,7 +10,7 @@ import (
 // type. The getters used to assert .(string) on the value directly, which
 // panicked the (recover-less) consumer goroutine and took the whole process
 // down on a single alert carrying a non-string value. These tests pin the
-// guarded behaviour.
+// guarded behavior.
 
 func TestGetPodNameNonStringValueDoesNotPanic(t *testing.T) {
 	var of map[string]any

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -1,0 +1,68 @@
+package events
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// A Falco alert is attacker-influenced JSON, so an output field can hold any
+// type. The getters used to assert .(string) on the value directly, which
+// panicked the (recover-less) consumer goroutine and took the whole process
+// down on a single alert carrying a non-string value. These tests pin the
+// guarded behaviour.
+
+func TestGetPodNameNonStringValueDoesNotPanic(t *testing.T) {
+	var of map[string]any
+	if err := json.Unmarshal([]byte(`{"k8s.pod.name": {"nested": "object"}}`), &of); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	e := &Event{OutputFields: of}
+
+	// Before the fix this panicked with
+	// "interface conversion: interface {} is map[string]interface {}, not string".
+	if got := e.GetPodName(); got != "" {
+		t.Fatalf("GetPodName() = %q, want empty string for a non-string field", got)
+	}
+}
+
+func TestGetPodNameStringValue(t *testing.T) {
+	e := &Event{OutputFields: map[string]any{"k8s.pod.name": "nginx"}}
+	if got := e.GetPodName(); got != "nginx" {
+		t.Fatalf("GetPodName() = %q, want %q", got, "nginx")
+	}
+}
+
+func TestGetRemotePortAcceptsNumericValue(t *testing.T) {
+	// Falco emits ports as JSON numbers. Depending on the decode path the value
+	// arrives as json.Number (handler, UseNumber) or float64 (consumer,
+	// plain json.Unmarshal); both must yield the port string, not a panic.
+	t.Run("json.Number", func(t *testing.T) {
+		e, err := DecodeEvent(strings.NewReader(`{"output_fields": {"fd.rport": 8080}}`))
+		if err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		if got := e.GetRemotePort(); got != "8080" {
+			t.Fatalf("GetRemotePort() = %q, want %q", got, "8080")
+		}
+	})
+	t.Run("float64", func(t *testing.T) {
+		var of map[string]any
+		if err := json.Unmarshal([]byte(`{"fd.rport": 8080}`), &of); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+		e := &Event{OutputFields: of}
+		if got := e.GetRemotePort(); got != "8080" {
+			t.Fatalf("GetRemotePort() = %q, want %q", got, "8080")
+		}
+	})
+}
+
+func TestGetRemoteProtocolReadsSourceProtocol(t *testing.T) {
+	// The second branch previously re-read fd.rproto, so an alert carrying only
+	// the source protocol returned "". It should fall back to fd.sproto.
+	e := &Event{OutputFields: map[string]any{"fd.sproto": "tcp"}}
+	if got := e.GetRemoteProtocol(); got != "tcp" {
+		t.Fatalf("GetRemoteProtocol() = %q, want %q", got, "tcp")
+	}
+}

--- a/internal/kubernetes/checks/checks.go
+++ b/internal/kubernetes/checks/checks.go
@@ -74,12 +74,14 @@ func CheckRemoteIP(event *events.Event) error {
 		return errors.New("missing IP field(s) (fd.sip or fd.rip)")
 	}
 	if event.OutputFields["fd.sip"] != nil {
-		if net.ParseIP(event.OutputFields["fd.sip"].(string)) == nil {
+		sip, ok := event.OutputFields["fd.sip"].(string)
+		if !ok || net.ParseIP(sip) == nil {
 			return errors.New("wrong value for fd.sip")
 		}
 	}
 	if event.OutputFields["fd.rip"] != nil {
-		if net.ParseIP(event.OutputFields["fd.rip"].(string)) == nil {
+		rip, ok := event.OutputFields["fd.rip"].(string)
+		if !ok || net.ParseIP(rip) == nil {
 			return errors.New("wrong value for fd.rip")
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area actionners
/area core

**What this PR does / why we need it**:

The event getters in `internal/events` read `OutputFields` values with a bare `.(string)` assertion. `OutputFields` is decoded straight from the alert JSON, so a field the actionners read (for example `k8s.pod.name`) can hold a non-string value, and the assertion then panics. `StartConsumer` runs the actionner consumer as a goroutine with no `recover`, so a single such event takes the whole process down instead of being skipped.

It also trips on legitimate input: Falco emits the port fields (`fd.sport`, `fd.rport`) as numbers, so the port getters panic on normal alerts that reach a rule which reads them.

This PR:

- guards every `OutputFields` assertion in `internal/events` and the `fd.sip` / `fd.rip` checks with the comma-ok form, keeping the numeric JSON forms (`json.Number` from the handler decode, `float64` from the consumer decode) so ports still resolve rather than returning empty;
- adds a deferred `recover` around per-event handling in `StartConsumer`, so a panic while processing one event is logged and skipped instead of terminating the daemon;
- fixes `GetRemoteProtocol`, whose second branch re-read `fd.rproto` instead of `fd.sproto`.

`GetHostname` reads a typed struct field and was already safe, so it is left as-is.

**Which issue(s) this PR fixes**:

This came out of a private report to the Falco maintainers list. @leogr verified it end to end and asked me to send the fix as a regular PR, since it is being handled in the open rather than as an advisory.

**Special notes for your reviewer**:

The tests in `internal/events/events_test.go` fail before this change (the non-string and numeric cases panic, the protocol case returns `""`) and pass after. `go build ./...`, `go vet`, and the existing `actionners` and `rules` suites are green.

```release-note
Fix a consumer crash when a Falco alert output field carries a non-string value, and resolve numeric port fields and the source protocol correctly.
```
