### PR TITLE
fix: use event.trace_id key for trace id tracing attribute

### DIFF
--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -529,7 +529,7 @@ func handleEvent(config *configuration.Configuration, m nats.MessageWithContext)
 			trace.WithAttributes(attribute.String("event.rule", event.Rule)),
 			trace.WithAttributes(attribute.String("event.output", event.Output)),
 			trace.WithAttributes(attribute.String("event.source", event.Source)),
-			trace.WithAttributes(attribute.String("event.source", event.TraceID)),
+			trace.WithAttributes(attribute.String("event.trace_id", event.TraceID)),
 			trace.WithAttributes(attribute.String("rule.name", i.GetName())),
 			trace.WithAttributes(attribute.String("rule.description", i.GetDescription())),
 		)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area core

**What this PR does / why we need it**:

When the actionner consumer builds the `match` span for a triggered event, two
attributes are set with the same key `event.source`: the first carries the event
source, the second carries the event trace id. Because both use the same key, the
trace id attribute overwrites (or is dropped alongside) the source attribute
depending on the exporter, and the trace id is never recorded under a meaningful
key on the span.

This PR fixes the second attribute so the trace id is recorded under its own key
`event.trace_id`, keeping `event.source` for the source value only.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Single-line change in `actionners/actionners.go`. `go build ./...` and `go vet`
are green.

Before:
```go
trace.WithAttributes(attribute.String("event.source", event.Source)),
trace.WithAttributes(attribute.String("event.source", event.TraceID)),
```
After:
```go
trace.WithAttributes(attribute.String("event.source", event.Source)),
trace.WithAttributes(attribute.String("event.trace_id", event.TraceID)),
```

Record the event trace id on the match span under the event.trace_id attribute instead of duplicating the event.source key.