### PR TITLE
ci: pin golangci-lint to v1.64.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: latest
+          version: v1.64.8


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area config

**What this PR does / why we need it**:

The lint workflow pins `golangci-lint-action@v4` but requests the linter with
`version: latest`. `latest` now resolves to golangci-lint v2.x, while the
repository's `.golangci.yml` is still written in the v1 configuration format
(no `version` field, `run.modules-download-mode`, `linters.disable-all`,
`linters-settings`, and linters that were removed in v2 such as `golint`,
`gosimple`, `deadcode`, `varcheck` and `scopelint`).

golangci-lint v2 refuses that config with:

Error: can't load config: unsupported version of the configuration: ""



and exits with code 3, so the `lint` job fails on every PR regardless of the
change it carries.

This PR pins the linter to `v1.64.8`, the last v1 release, which is compatible
with both `golangci-lint-action@v4` and the existing `.golangci.yml`. This
restores the lint job immediately. Migrating the configuration to the v2 format
(and moving back to `latest`) can be done in a dedicated follow-up.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Reproduced locally with golangci-lint v2.12.2 (the current `latest`), which
fails to load `.golangci.yml` with the error above. Pinning to `v1.64.8` loads
the config as expected.

Single-line change in `.github/workflows/lint.yml`:

```diff
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: latest
+          version: v1.64.8
