### PR TITLE
ci: migrate golangci-lint config to v2 and fix findings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.25'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v7
         with:
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,58 +1,68 @@
+version: "2"
+
 run:
   timeout: 5m
   modules-download-mode: readonly
 
-linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/falcosecurity/falco-talon
-  golint:
-    min-confidence: 0
-  govet:
-    shadow: true
-    enable-all: true
-  misspell:
-    locale: US
-
 linters:
-  disable-all: true
+  default: none
   enable:
     - bodyclose
     - errcheck
     - goconst
     - gocritic
-    - gofmt
-    - goimports
-    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unused
     - whitespace
+  settings:
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    govet:
+      enable-all: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        # This project does not document every exported symbol/package; the
+        # comment rules would flag hundreds of pre-existing symbols. Keep the
+        # rest of revive's default rules by enabling all and disabling only
+        # these two.
+        - name: exported
+          disabled: true
+        - name: package-comments
+          disabled: true
+  exclusions:
+    rules:
+      - path: server/manifest.go
+        linters:
+          - unused
+      - path: server/configuration.go
+        linters:
+          - unused
+      - path: _test.go
+        linters:
+          - bodyclose
+          - goconst
 
 issues:
-  exclude-rules:
-    - path: server/manifest.go
-      linters:
-        - deadcode
-        - unused
-        - varcheck
-    - path: server/configuration.go
-      linters:
-        - unused
-    - path: _test.go
-      linters:
-        - bodyclose
-        - goconst
-        - scopelint # https://github.com/kyoh86/scopelint/issues/4
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+    goimports:
+      local-prefixes:
+        - github.com/falcosecurity/falco-talon

--- a/actionners/actionners.go
+++ b/actionners/actionners.go
@@ -59,8 +59,10 @@ var defaultActionners *Actionners
 var enabledActionners *Actionners
 
 const (
-	trueStr  string = "true"
-	falseStr string = "false"
+	trueStr   string = "true"
+	falseStr  string = "false"
+	outputStr string = "output"
+	eventStr  string = "event"
 )
 
 func init() {
@@ -274,10 +276,10 @@ func runAction(mctx context.Context, rule *rules.Rule, action *rules.Action, eve
 	go notifiers.Notify(actx, rule, action, event, log)
 
 	if actionner.Information().RequireOutput {
-		octx, span := tracer.Start(actx, "output")
+		octx, span := tracer.Start(actx, outputStr)
 
 		logO := utils.LogLine{
-			Message: "output",
+			Message: outputStr,
 			Action:  action.GetName(),
 			TraceID: event.TraceID,
 		}
@@ -379,10 +381,10 @@ func runAction(mctx context.Context, rule *rules.Rule, action *rules.Action, eve
 	}
 
 	if actionner.Information().AllowOutput && output != nil && data != nil {
-		octx, span := tracer.Start(actx, "output")
+		octx, span := tracer.Start(actx, outputStr)
 
 		logO := utils.LogLine{
-			Message: "output",
+			Message: outputStr,
 			Rule:    rule.GetName(),
 			Action:  action.GetName(),
 			TraceID: event.TraceID,
@@ -476,7 +478,7 @@ func StartConsumer(eventsC <-chan nats.MessageWithContext) {
 		}
 
 		log := utils.LogLine{
-			Message:  "event",
+			Message:  eventStr,
 			Event:    event.Rule,
 			Priority: event.Priority,
 			Output:   event.Output,

--- a/actionners/aws/lambda/lambda.go
+++ b/actionners/aws/lambda/lambda.go
@@ -51,6 +51,11 @@ const (
 `
 )
 
+const (
+	latestVersion       string = "$LATEST"
+	requestResponseType string = "RequestResponse"
+)
+
 var (
 	RequiredOutputFields = []string{}
 )
@@ -90,8 +95,8 @@ func (a Actionner) Information() models.Information {
 func (a Actionner) Parameters() models.Parameters {
 	return Parameters{
 		AWSLambdaName:           "",
-		AWSLambdaAliasOrVersion: "$LATEST",
-		AWSLambdaInvocationType: "RequestResponse",
+		AWSLambdaAliasOrVersion: latestVersion,
+		AWSLambdaInvocationType: requestResponseType,
 	}
 }
 
@@ -175,7 +180,7 @@ func (a Actionner) CheckParameters(action *rules.Action) error {
 
 func getInvocationType(invocationType string) types.InvocationType {
 	switch invocationType {
-	case "RequestResponse":
+	case requestResponseType:
 		return types.InvocationTypeRequestResponse
 	case "Event":
 		return types.InvocationTypeEvent
@@ -188,7 +193,7 @@ func getInvocationType(invocationType string) types.InvocationType {
 
 func getLambdaVersion(qualifier *string) *string {
 	if qualifier == nil || *qualifier == "" {
-		defaultVal := "$LATEST"
+		defaultVal := latestVersion
 		return &defaultVal
 	}
 	return qualifier

--- a/actionners/calico/networkpolicy/networkpolicy.go
+++ b/actionners/calico/networkpolicy/networkpolicy.go
@@ -100,6 +100,9 @@ type Parameters struct {
 
 const mask32 string = "/32"
 const managedByStr string = "app.k8s.io/managed-by"
+const anyCIDR string = "0.0.0.0/0"
+const actionAllow networkingv3.Action = "Allow"
+const actionDeny networkingv3.Action = "Deny"
 
 type Actionner struct{}
 
@@ -128,7 +131,7 @@ func (a Actionner) Information() models.Information {
 }
 func (a Actionner) Parameters() models.Parameters {
 	return Parameters{
-		AllowCIDR:       []string{"0.0.0.0/0"},
+		AllowCIDR:       []string{anyCIDR},
 		AllowNamespaces: []string{},
 		Order:           0,
 	}
@@ -189,7 +192,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					Status:  utils.FailureStr,
 				}, nil, err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "StatefulSet":
 			u, err2 := k8sClient.GetStatefulsetFromPod(pod)
@@ -200,7 +203,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					Status:  utils.FailureStr,
 				}, nil, err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "ReplicaSet":
 			u, err2 := k8sClient.GetReplicasetFromPod(pod)
@@ -211,12 +214,12 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					Status:  utils.FailureStr,
 				}, nil, err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		}
 	} else {
-		owner = pod.ObjectMeta.Name
-		labels = pod.ObjectMeta.Labels
+		owner = pod.Name
+		labels = pod.Labels
 	}
 
 	if owner == "" || len(labels) == 0 {
@@ -260,9 +263,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 
 	if parameters.AllowCIDR == nil && parameters.AllowNamespaces == nil {
 		allowCIDRRule = &networkingv3.Rule{
-			Action: "Allow",
+			Action: actionAllow,
 			Destination: networkingv3.EntityRule{
-				Nets: []string{"0.0.0.0/0"},
+				Nets: []string{anyCIDR},
 			},
 		}
 		allowNamespacesRule = nil
@@ -318,10 +321,10 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 			Status:  utils.FailureStr,
 		}, nil, err
 	}
-	payload.ObjectMeta.ResourceVersion = netpol.ObjectMeta.ResourceVersion
+	payload.ResourceVersion = netpol.ResourceVersion
 	var denyCIDR []string
 	for _, i := range netpol.Spec.Egress {
-		if i.Action == "Deny" {
+		if i.Action == actionDeny {
 			denyCIDR = append(denyCIDR, i.Destination.Nets...)
 		}
 	}
@@ -359,7 +362,7 @@ func createAllowCIDREgressRule(parameters *Parameters) *networkingv3.Rule {
 	}
 
 	rule := networkingv3.Rule{
-		Action:      "Allow",
+		Action:      actionAllow,
 		Destination: networkingv3.EntityRule{},
 	}
 
@@ -374,7 +377,7 @@ func createAllowNamespaceEgressRule(parameters *Parameters) *networkingv3.Rule {
 	}
 
 	rule := networkingv3.Rule{
-		Action:      "Allow",
+		Action:      actionAllow,
 		Destination: networkingv3.EntityRule{},
 	}
 
@@ -392,7 +395,7 @@ func createAllowNamespaceEgressRule(parameters *Parameters) *networkingv3.Rule {
 
 func createDenyEgressRule(ips []string) *networkingv3.Rule {
 	r := networkingv3.Rule{
-		Action: "Deny",
+		Action: actionDeny,
 		Destination: networkingv3.EntityRule{
 			Nets: ips,
 		},

--- a/actionners/cilium/networkpolicy/networkpolicy.go
+++ b/actionners/cilium/networkpolicy/networkpolicy.go
@@ -102,6 +102,7 @@ const (
 	managedByStr      string = "app.k8s.io/managed-by"
 	netpolDescription string = "Network policy created by Falco Talon"
 	namespaceKey             = "k8s.io/metadata.name"
+	anyCIDR                  = "0.0.0.0/0"
 )
 
 type Actionner struct{}
@@ -131,7 +132,7 @@ func (a Actionner) Information() models.Information {
 }
 func (a Actionner) Parameters() models.Parameters {
 	return Parameters{
-		AllowCIDR:       []string{"0.0.0.0/0"},
+		AllowCIDR:       []string{anyCIDR},
 		AllowNamespaces: []string{},
 	}
 }
@@ -191,7 +192,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "StatefulSet":
 			u, err2 := k8sClient.GetStatefulsetFromPod(pod)
@@ -204,7 +205,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "ReplicaSet":
 			u, err2 := k8sClient.GetReplicasetFromPod(pod)
@@ -217,12 +218,12 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		}
 	} else {
-		owner = pod.ObjectMeta.Name
-		labels = pod.ObjectMeta.Labels
+		owner = pod.Name
+		labels = pod.Labels
 	}
 
 	if owner == "" || len(labels) == 0 {
@@ -268,7 +269,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	if parameters.AllowCIDR == nil && parameters.AllowNamespaces == nil {
 		allowCIDRRule = &api.EgressRule{
 			EgressCommonRule: api.EgressCommonRule{
-				ToCIDR: api.CIDRSlice{"0.0.0.0/0"},
+				ToCIDR: api.CIDRSlice{anyCIDR},
 			},
 		}
 	} else {
@@ -329,7 +330,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 			err
 	}
 
-	payload.ObjectMeta.ResourceVersion = netpol.ObjectMeta.ResourceVersion
+	payload.ResourceVersion = netpol.ResourceVersion
 	payload.Spec.Egress = netpol.Spec.Egress
 	payload.Spec.EgressDeny = netpol.Spec.EgressDeny
 

--- a/actionners/gcp/function/function.go
+++ b/actionners/gcp/function/function.go
@@ -226,7 +226,7 @@ func (a Actionner) RunWithClient(c client.GCPClientAPI, event *events.Event, act
 			Status:  utils.FailureStr,
 		}, nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/actionners/kubernetes/annotation/annotation.go
+++ b/actionners/kubernetes/annotation/annotation.go
@@ -151,9 +151,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 			}, nil, err
 		}
 		objects[nodeStr] = node.Name
-		if node.ObjectMeta.Annotations == nil {
-			node.ObjectMeta.Annotations = make(map[string]string)
-			node.ObjectMeta.Annotations[podStr] = podStr
+		if node.Annotations == nil {
+			node.Annotations = make(map[string]string)
+			node.Annotations[podStr] = podStr
 			parameters.Annotations[podStr] = ""
 			_, err = client.Clientset.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
 			if err != nil {
@@ -168,9 +168,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		kind = podStr
 		objects[podStr] = podName
 		objects["namespace"] = namespace
-		if pod.ObjectMeta.Annotations == nil {
-			pod.ObjectMeta.Annotations = make(map[string]string)
-			pod.ObjectMeta.Annotations[podStr] = podStr
+		if pod.Annotations == nil {
+			pod.Annotations = make(map[string]string)
+			pod.Annotations[podStr] = podStr
 			parameters.Annotations[podStr] = ""
 			_, err = client.Clientset.CoreV1().Pods(namespace).Update(context.Background(), pod, metav1.UpdateOptions{})
 			if err != nil {

--- a/actionners/kubernetes/exec/exec.go
+++ b/actionners/kubernetes/exec/exec.go
@@ -50,6 +50,8 @@ rules:
 `
 )
 
+const binSh string = "/bin/sh"
+
 var (
 	RequiredOutputFields = []string{"k8s.ns.name", "k8s.pod.name"}
 )
@@ -87,7 +89,7 @@ func (a Actionner) Information() models.Information {
 func (a Actionner) Parameters() models.Parameters {
 	return Parameters{
 		Command: "",
-		Shell:   "/bin/sh",
+		Shell:   binSh,
 	}
 }
 
@@ -118,7 +120,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	if parameters.Shell != "" {
 		*shell = parameters.Shell
 	} else {
-		*shell = "/bin/sh"
+		*shell = binSh
 	}
 
 	command := new(string)

--- a/actionners/kubernetes/label/label.go
+++ b/actionners/kubernetes/label/label.go
@@ -151,9 +151,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 			}, nil, err
 		}
 		objects[nodeStr] = node.Name
-		if node.ObjectMeta.Labels == nil {
-			node.ObjectMeta.Labels = make(map[string]string)
-			node.ObjectMeta.Labels[podStr] = podStr
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+			node.Labels[podStr] = podStr
 			parameters.Labels[podStr] = ""
 			_, err = client.Clientset.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
 			if err != nil {
@@ -168,9 +168,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		kind = podStr
 		objects[podStr] = podName
 		objects["namespace"] = namespace
-		if pod.ObjectMeta.Labels == nil {
-			pod.ObjectMeta.Labels = make(map[string]string)
-			pod.ObjectMeta.Labels[podStr] = podStr
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string)
+			pod.Labels[podStr] = podStr
 			parameters.Labels[podStr] = ""
 			_, err = client.Clientset.CoreV1().Pods(namespace).Update(context.Background(), pod, metav1.UpdateOptions{})
 			if err != nil {

--- a/actionners/kubernetes/log/log.go
+++ b/actionners/kubernetes/log/log.go
@@ -159,7 +159,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 			}
 			continue
 		}
-		defer logs.Close()
+		defer func() { _ = logs.Close() }()
 
 		buf := new(bytes.Buffer)
 		_, err = io.Copy(buf, logs)

--- a/actionners/kubernetes/networkpolicy/networkpolicy.go
+++ b/actionners/kubernetes/networkpolicy/networkpolicy.go
@@ -178,7 +178,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "StatefulSet":
 			u, err2 := client.GetStatefulsetFromPod(pod)
@@ -191,7 +191,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		case "ReplicaSet":
 			u, err2 := client.GetReplicasetFromPod(pod)
@@ -204,12 +204,12 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 					nil,
 					err2
 			}
-			owner = u.ObjectMeta.Name
+			owner = u.Name
 			labels = u.Spec.Selector.MatchLabels
 		}
 	} else {
-		owner = pod.ObjectMeta.Name
-		labels = pod.ObjectMeta.Labels
+		owner = pod.Name
+		labels = pod.Labels
 	}
 
 	if owner == "" || len(labels) == 0 {

--- a/actionners/kubernetes/script/script.go
+++ b/actionners/kubernetes/script/script.go
@@ -55,6 +55,11 @@ rules:
 `
 )
 
+const (
+	binSh      string = "/bin/sh"
+	scriptPath string = "/tmp/talon-script.sh"
+)
+
 var (
 	RequiredOutputFields = []string{"k8s.ns.name", "k8s.pod.name"}
 )
@@ -94,7 +99,7 @@ func (a Actionner) Parameters() models.Parameters {
 	return Parameters{
 		Script: "",
 		File:   "",
-		Shell:  "/bin/sh",
+		Shell:  binSh,
 	}
 }
 
@@ -125,7 +130,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	if parameters.Shell != "" {
 		*shell = parameters.Shell
 	} else {
-		*shell = "/bin/sh"
+		*shell = binSh
 	}
 
 	script := new(string)
@@ -170,7 +175,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	output := new(bytes.Buffer)
 	for i, j := range containers {
 		container = j
-		command := []string{"tee", "/tmp/talon-script.sh", ">", "/dev/null"}
+		command := []string{"tee", scriptPath, ">", "/dev/null"}
 		_, err = client.Exec(namespace, pod, container, command, *script)
 		if err != nil {
 			if i == len(containers)-1 {
@@ -185,7 +190,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	}
 
 	// run the script
-	command := []string{*shell, "/tmp/talon-script.sh"}
+	command := []string{*shell, scriptPath}
 	output, err = client.Exec(namespace, pod, container, command, "")
 	if err != nil {
 		return utils.LogLine{

--- a/actionners/kubernetes/sysdig/sysdig.go
+++ b/actionners/kubernetes/sysdig/sysdig.go
@@ -85,6 +85,7 @@ const (
 	defaultDuration    int    = 5
 	defaultMaxDuration int    = 30
 	defaultBufferSize  int    = 2048
+	scriptPath         string = "/tmp/talon-script.sh"
 )
 
 type Actionner struct{}
@@ -131,8 +132,8 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 	namespace := event.GetNamespaceName()
 
 	objects := map[string]string{
-		"pod":       podName,
-		"namespace": namespace,
+		defaultScope: podName,
+		"namespace":  namespace,
 	}
 
 	var parameters Parameters
@@ -220,9 +221,9 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}
 	}
 
-	command := []string{"tee", "/tmp/talon-script.sh", "/dev/null"}
+	command := []string{"tee", scriptPath, "/dev/null"}
 	sysdigCmd := fmt.Sprintf("sysdig --modern-bpf --cri /run/containerd/containerd.sock -M %v -s %v -z -w /tmp/sysdig.scap.gz", parameters.Duration, parameters.BufferSize)
-	if parameters.Scope == "pod" {
+	if parameters.Scope == defaultScope {
 		containers := []string{}
 		for _, i := range pod.Status.ContainerStatuses {
 			containers = append(containers, strings.ReplaceAll(i.ContainerID, "containerd://", "")[:12])
@@ -239,7 +240,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}, nil, err
 	}
 
-	command = []string{"sh", "/tmp/talon-script.sh"}
+	command = []string{"sh", scriptPath}
 	_, err = client.Exec(namespace, jPod, jContainer, command, "")
 	if err != nil {
 		return utils.LogLine{

--- a/actionners/kubernetes/tcpdump/tcpdump.go
+++ b/actionners/kubernetes/tcpdump/tcpdump.go
@@ -80,6 +80,7 @@ const (
 	defaultTTL      int    = 60
 	defaultDuration int    = 5
 	defaulSnaplen   int    = 4096
+	scriptPath      string = "/tmp/talon-script.sh"
 )
 
 type Actionner struct{}
@@ -171,7 +172,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}, nil, err
 	}
 
-	command := []string{"tee", "/tmp/talon-script.sh", "/dev/null"}
+	command := []string{"tee", scriptPath, "/dev/null"}
 	script := fmt.Sprintf("timeout %vs tcpdump -n -i any -s %v -w /tmp/tcpdump.pcap || [ $? -eq 124 ] && echo OK || exit 1\n", parameters.Duration, parameters.Snaplen)
 	_, err = client.Exec(namespace, podName, ephemeralContainerName, command, script)
 	if err != nil {
@@ -182,7 +183,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		}, nil, err
 	}
 
-	command = []string{"sh", "/tmp/talon-script.sh"}
+	command = []string{"sh", scriptPath}
 	_, err = client.Exec(namespace, podName, ephemeralContainerName, command, "")
 	if err != nil {
 		return utils.LogLine{

--- a/actionners/kubernetes/terminate/terminate.go
+++ b/actionners/kubernetes/terminate/terminate.go
@@ -55,6 +55,8 @@ rules:
 `
 )
 
+const ignoredStr string = "ignored"
+
 var (
 	RequiredOutputFields = []string{"k8s.ns.name", "k8s.pod.name"}
 )
@@ -147,7 +149,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		if parameters.IgnoreDaemonsets {
 			return utils.LogLine{
 				Objects: objects,
-				Status:  "ignored",
+				Status:  ignoredStr,
 				Result:  fmt.Sprintf("the pod '%v' in the namespace '%v' belongs to a DaemonSet and will be ignored.", podName, namespace),
 			}, nil, nil
 		}
@@ -155,7 +157,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		if parameters.IgnoreStatefulSets {
 			return utils.LogLine{
 				Objects: objects,
-				Status:  "ignored",
+				Status:  ignoredStr,
 				Result:  fmt.Sprintf("the pod '%v' in the namespace '%v' belongs to a StatefulSet and will be ignored.", podName, namespace),
 			}, nil, nil
 		}
@@ -198,7 +200,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 				if healthyReplicasCount < minHealthyReplicasValue {
 					return utils.LogLine{
 						Objects: objects,
-						Status:  "ignored",
+						Status:  ignoredStr,
 						Result:  fmt.Sprintf("the pod '%v' in the namespace '%v' belongs to a ReplicaSet without enough healthy replicas and will be ignored.", podName, namespace),
 					}, nil, nil
 				}
@@ -214,7 +216,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 				if healthyReplicasPercent < minHealthyReplicasValue {
 					return utils.LogLine{
 						Objects: objects,
-						Status:  "ignored",
+						Status:  ignoredStr,
 						Result:  fmt.Sprintf("the pod '%v' in the namespace '%v' belongs to a ReplicaSet without enough healthy replicas and will be ignored.", podName, namespace),
 					}, nil, nil
 				}
@@ -224,7 +226,7 @@ func (a Actionner) Run(event *events.Event, action *rules.Action) (utils.LogLine
 		if parameters.IgnoreStandalonePods {
 			return utils.LogLine{
 				Objects: objects,
-				Status:  "ignored",
+				Status:  ignoredStr,
 				Result:  fmt.Sprintf("the pod '%v' in the namespace '%v' is a standalone pod and will be ignored.", podName, namespace),
 			}, nil, nil
 		}

--- a/cmd/actionners.go
+++ b/cmd/actionners.go
@@ -12,14 +12,14 @@ import (
 )
 
 var actionnersCmd = &cobra.Command{
-	Use:   "actionners",
-	Short: "Manage the actionners",
-	Long:  "Manage the actionners",
+	Use:   actionnersStr,
+	Short: manageActionnersStr,
+	Long:  manageActionnersStr,
 	Run:   nil,
 }
 
 var actionnersListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   listStr,
 	Short: "List the available Actionners",
 	Long:  "List the available Actionners.",
 	Run: func(_ *cobra.Command, _ []string) {
@@ -57,7 +57,7 @@ var actionnersListCmd = &cobra.Command{
 
 			if p := i.Parameters(); p != nil {
 				valueOf := reflect.ValueOf(i.Parameters())
-				if valueOf.Kind() == reflect.Ptr {
+				if valueOf.Kind() == reflect.Pointer {
 					valueOf = valueOf.Elem()
 				}
 

--- a/cmd/notifiers.go
+++ b/cmd/notifiers.go
@@ -19,7 +19,7 @@ var notifiersCmd = &cobra.Command{
 }
 
 var notifiersListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   listStr,
 	Short: "List the available Notifiers",
 	Long:  "List the available Notifiers.",
 	Run: func(_ *cobra.Command, _ []string) {
@@ -43,7 +43,7 @@ var notifiersListCmd = &cobra.Command{
 
 			if p := i.Parameters(); p != nil {
 				valueOf := reflect.ValueOf(i.Parameters())
-				if valueOf.Kind() == reflect.Ptr {
+				if valueOf.Kind() == reflect.Pointer {
 					valueOf = valueOf.Elem()
 				}
 

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -12,14 +12,14 @@ import (
 )
 
 var outputsCmd = &cobra.Command{
-	Use:   "outputs",
+	Use:   outputsStr,
 	Short: "Manage the Outputs",
 	Long:  "Manage the Outputs.",
 	Run:   nil,
 }
 
 var outputsListCmd = &cobra.Command{
-	Use:   "list",
+	Use:   listStr,
 	Short: "List the available Outputs",
 	Long:  "List the available Outputs.",
 	Run: func(_ *cobra.Command, _ []string) {
@@ -45,7 +45,7 @@ var outputsListCmd = &cobra.Command{
 
 			if p := i.Parameters(); p != nil {
 				valueOf := reflect.ValueOf(i.Parameters())
-				if valueOf.Kind() == reflect.Ptr {
+				if valueOf.Kind() == reflect.Pointer {
 					valueOf = valueOf.Elem()
 				}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,19 @@ import (
 
 const (
 	requiredStr = " (required)"
+
+	actionnersStr       = "actionners"
+	manageActionnersStr = "Manage the actionners"
+	listStr             = "list"
+	outputsStr          = "outputs"
+	rulesStr            = "rules"
+	checkRulesStr       = "Check Falco Talon Rules file"
+	invalidRulesStr     = "invalid rules"
+	initStr             = "init"
+	natsStr             = "nats"
+	leaseStr            = "lease"
+	httpStr             = "http"
+	otelTracesStr       = "otel-traces"
 )
 
 var RootCmd = &cobra.Command{
@@ -36,7 +49,7 @@ func init() {
 	actionnersCmd.AddCommand(actionnersListCmd)
 	outputsCmd.AddCommand(outputsListCmd)
 	notifiersCmd.AddCommand(notifiersListCmd)
-	RootCmd.PersistentFlags().StringArrayP("rules", "r", []string{}, "Falco Talon Rules File")
+	RootCmd.PersistentFlags().StringArrayP(rulesStr, "r", []string{}, "Falco Talon Rules File")
 	serverCmd.Flags().StringP("config", "c", "/etc/falco-talon/config.yaml", "Falco Talon Config File")
 	rulesCmd.PersistentFlags().StringP("config", "c", "", "Falco Talon Config File")
 	actionnersCmd.PersistentFlags().StringP("config", "c", "", "Falco Talon Config File")

--- a/cmd/rule_validation.go
+++ b/cmd/rule_validation.go
@@ -21,7 +21,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 					Rule:      rule.GetName(),
 					Action:    action.GetName(),
 					Actionner: action.GetActionner(),
-					Message:   "rules",
+					Message:   rulesStr,
 				})
 				valid = false
 				continue
@@ -33,7 +33,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 					Rule:      rule.GetName(),
 					Action:    action.GetName(),
 					Actionner: action.GetActionner(),
-					Message:   "rules",
+					Message:   rulesStr,
 				})
 				valid = false
 			}
@@ -46,7 +46,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 						Rule:      rule.GetName(),
 						Action:    action.GetName(),
 						Actionner: action.GetActionner(),
-						Message:   "rules",
+						Message:   rulesStr,
 					})
 					valid = false
 				}
@@ -60,7 +60,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 					Rule:         rule.GetName(),
 					Action:       action.GetName(),
 					OutputTarget: output.GetTarget(),
-					Message:      "rules",
+					Message:      rulesStr,
 				})
 				valid = false
 				continue
@@ -72,7 +72,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 					Rule:         rule.GetName(),
 					Action:       action.GetName(),
 					OutputTarget: output.GetTarget(),
-					Message:      "rules",
+					Message:      rulesStr,
 				})
 				valid = false
 				continue
@@ -84,7 +84,7 @@ func validateRules(rules *[]*ruleengine.Rule) bool {
 					Rule:         rule.GetName(),
 					Action:       action.GetName(),
 					OutputTarget: output.GetTarget(),
-					Message:      "rules",
+					Message:      rulesStr,
 				})
 				valid = false
 			}

--- a/cmd/rules.go
+++ b/cmd/rules.go
@@ -13,31 +13,31 @@ import (
 )
 
 var rulesCmd = &cobra.Command{
-	Use:   "rules",
+	Use:   rulesStr,
 	Short: "Manage Falco Talon rules",
 	Long:  `Manage the rules loaded by Falco Talon. You can print them in the stdout or check their validity.`,
 }
 
 var rulesChecksCmd = &cobra.Command{
 	Use:   "check",
-	Short: "Check Falco Talon Rules file",
-	Long:  "Check Falco Talon Rules file",
+	Short: checkRulesStr,
+	Long:  checkRulesStr,
 	Run: func(cmd *cobra.Command, _ []string) {
 		configFile, _ := cmd.Flags().GetString("config")
 		config := configuration.CreateConfiguration(configFile)
 		utils.SetLogFormat(config.LogFormat)
-		rulesFiles, _ := cmd.Flags().GetStringArray("rules")
+		rulesFiles, _ := cmd.Flags().GetStringArray(rulesStr)
 		if len(rulesFiles) != 0 {
 			config.RulesFiles = rulesFiles
 		}
 		rules := ruleengine.ParseRules(config.RulesFiles)
 		if rules == nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 		}
 		if !validateRules(rules) {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 		}
-		utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "rules file valid", Message: "rules"})
+		utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "rules file valid", Message: rulesStr})
 	},
 }
 
@@ -49,13 +49,13 @@ var rulesPrintCmd = &cobra.Command{
 		configFile, _ := cmd.Flags().GetString("config")
 		config := configuration.CreateConfiguration(configFile)
 		utils.SetLogFormat(config.LogFormat)
-		rulesFiles, _ := cmd.Flags().GetStringArray("rules")
+		rulesFiles, _ := cmd.Flags().GetStringArray(rulesStr)
 		if len(rulesFiles) != 0 {
 			config.RulesFiles = rulesFiles
 		}
 		rules := ruleengine.ParseRules(config.RulesFiles)
 		if rules == nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 		}
 		type yamlFile struct {
 			Name        string   `yaml:"rule"`

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -34,38 +34,38 @@ var serverCmd = &cobra.Command{
 		configFile, _ := cmd.Flags().GetString("config")
 		config := configuration.CreateConfiguration(configFile)
 		utils.SetLogFormat(config.LogFormat)
-		rulesFiles, _ := cmd.Flags().GetStringArray("rules")
+		rulesFiles, _ := cmd.Flags().GetStringArray(rulesStr)
 		if len(rulesFiles) != 0 {
 			config.RulesFiles = rulesFiles
 		}
 		rules := ruleengine.ParseRules(config.RulesFiles)
 		if rules == nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 		}
 
 		if !validateRules(rules) {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 		}
 
 		// init actionners
 		if err := actionners.Init(); err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "actionners"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: actionnersStr})
 		}
 
 		// init outputs
 		if err := outputs.Init(); err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "outputs"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: outputsStr})
 		}
 
 		// init notifiers
 		notifiers.Init()
 
 		if rules != nil {
-			utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rule(s) has/have been successfully loaded", len(*rules)), Message: "init"})
+			utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rule(s) has/have been successfully loaded", len(*rules)), Message: initStr})
 		}
 
 		if config.WatchRules {
-			utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "watch of rules enabled", Message: "init"})
+			utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "watch of rules enabled", Message: initStr})
 		}
 
 		srv := http.Server{
@@ -80,13 +80,13 @@ var serverCmd = &cobra.Command{
 				ignore := false
 				watcher, err := fsnotify.NewWatcher()
 				if err != nil {
-					utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "rules"})
+					utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: rulesStr})
 					return
 				}
-				defer watcher.Close()
+				defer func() { _ = watcher.Close() }()
 				for _, i := range config.RulesFiles {
 					if err := watcher.Add(i); err != nil {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "rules"})
+						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: rulesStr})
 						return
 					}
 				}
@@ -99,28 +99,28 @@ var serverCmd = &cobra.Command{
 								time.Sleep(1 * time.Second)
 								ignore = false
 							}()
-							utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "changes detected", Message: "rules"})
+							utils.PrintLog(utils.InfoStr, utils.LogLine{Result: "changes detected", Message: rulesStr})
 							newRules := ruleengine.ParseRules(config.RulesFiles)
 							if newRules == nil {
-								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+								utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 								break
 							}
 
 							if newRules != nil {
 								if !validateRules(newRules) {
-									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "invalid rules", Message: "rules"})
+									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: invalidRulesStr, Message: rulesStr})
 									break
 								}
-								utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rules have been successfully loaded", len(*newRules)), Message: "rules"})
+								utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("%v rules have been successfully loaded", len(*newRules)), Message: rulesStr})
 								rules = newRules
 								if err := actionners.Init(); err != nil {
-									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "actionners"})
+									utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: actionnersStr})
 									break
 								}
 							}
 						}
 					case err := <-watcher.Errors:
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "rules"})
+						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: rulesStr})
 					}
 				}
 			}()
@@ -128,7 +128,7 @@ var serverCmd = &cobra.Command{
 		// start the local NATS
 		ns, err := nats.StartServer(config.Deduplication.TimeWindowSeconds)
 		if err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "nats"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: natsStr})
 		}
 		defer ns.Shutdown()
 
@@ -137,21 +137,21 @@ var serverCmd = &cobra.Command{
 			go func() {
 				err2 := k8s.Init()
 				if err2 != nil {
-					utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: "lease"})
+					utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: leaseStr})
 				}
 				c, err2 := k8s.GetClient().GetLeaseHolder()
 				if err2 != nil {
-					utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: "lease"})
+					utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: leaseStr})
 				}
 				for {
 					s := <-c
 					if s == *utils.GetLocalIP() {
 						s = "127.0.0.1"
 					}
-					utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("new leader detected '%v'", s), Message: "nats"})
+					utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("new leader detected '%v'", s), Message: natsStr})
 					err2 = nats.GetPublisher().SetJetStreamContext("nats://" + s + ":4222")
 					if err2 != nil {
-						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err2.Error(), Message: "nats"})
+						utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err2.Error(), Message: natsStr})
 					}
 				}
 			}()
@@ -161,27 +161,27 @@ var serverCmd = &cobra.Command{
 		c, err := nats.GetConsumer().ConsumeMsg()
 
 		if err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "nats"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: natsStr})
 		}
 		go actionners.StartConsumer(c)
 
-		utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("Falco Talon is up and listening on %s:%d", config.ListenAddress, config.ListenPort), Message: "http"})
+		utils.PrintLog(utils.InfoStr, utils.LogLine{Result: fmt.Sprintf("Falco Talon is up and listening on %s:%d", config.ListenAddress, config.ListenPort), Message: httpStr})
 
 		ctx := context.Background()
 		otelShutdown, err := traces.SetupOTelSDK(ctx)
 		if err != nil {
-			utils.PrintLog(utils.WarningStr, utils.LogLine{Error: err.Error(), Message: "otel-traces"})
+			utils.PrintLog(utils.WarningStr, utils.LogLine{Error: err.Error(), Message: otelTracesStr})
 		}
 		defer func() {
 			if err := otelShutdown(ctx); err != nil {
-				utils.PrintLog(utils.WarningStr, utils.LogLine{Error: err.Error(), Message: "otel-traces"})
+				utils.PrintLog(utils.WarningStr, utils.LogLine{Error: err.Error(), Message: otelTracesStr})
 			}
 		}()
 
 		metrics.Init()
 
 		if err := srv.ListenAndServe(); err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "http"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: httpStr})
 		}
 	},
 }

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -23,6 +23,7 @@ const (
 	defaultOtelCollectorUseInsecureGrpc bool   = false
 	defaultOtelCollectorPort            int    = 4317
 	defaultOtelCollectorGRPCTimeout            = 10
+	configStr                           string = "config"
 )
 
 type Otel struct {
@@ -107,12 +108,12 @@ func CreateConfiguration(configFile string) *Configuration {
 		v.SetConfigFile(configFile)
 		err := v.ReadInConfig()
 		if err != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: fmt.Sprintf("error when reading config file: '%v'", err.Error()), Message: "config"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: fmt.Sprintf("error when reading config file: '%v'", err.Error()), Message: configStr})
 		}
 	}
 
 	if err := v.Unmarshal(config); err != nil {
-		utils.PrintLog(utils.FatalStr, utils.LogLine{Error: fmt.Sprintf("error unmarshalling config file: '%v'", err.Error()), Message: "config"})
+		utils.PrintLog(utils.FatalStr, utils.LogLine{Error: fmt.Sprintf("error unmarshalling config file: '%v'", err.Error()), Message: configStr})
 	}
 
 	return config

--- a/configuration/version.go
+++ b/configuration/version.go
@@ -50,14 +50,14 @@ func (i *Info) String() string {
 	b := strings.Builder{}
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
-	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
-	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
-	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
-	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
-	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
-	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+	_, _ = fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	_, _ = fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	_, _ = fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	_, _ = fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	_, _ = fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	_, _ = fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	_, _ = fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
 
-	w.Flush()
+	_ = w.Flush()
 	return b.String()
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -154,21 +154,21 @@ func (event *Event) ExportEnvVars() {
 		key := strings.ReplaceAll(strings.ToUpper(i), ".", "_")
 		key = strings.ReplaceAll(key, "[", "_")
 		key = strings.ReplaceAll(key, "]", "")
-		os.Setenv(key, fmt.Sprintf("%v", j))
+		_ = os.Setenv(key, fmt.Sprintf("%v", j))
 	}
 	for i, j := range event.Context {
 		key := strings.ReplaceAll(strings.ToUpper(i), ".", "_")
-		os.Setenv(key, fmt.Sprintf("%v", j))
+		_ = os.Setenv(key, fmt.Sprintf("%v", j))
 	}
-	os.Setenv("PRIORITY", event.Priority)
-	os.Setenv("HOSTNAME", event.Hostname)
-	os.Setenv("RULE", event.Rule)
-	os.Setenv("SOURCE", event.Source)
+	_ = os.Setenv("PRIORITY", event.Priority)
+	_ = os.Setenv("HOSTNAME", event.Hostname)
+	_ = os.Setenv("RULE", event.Rule)
+	_ = os.Setenv("SOURCE", event.Source)
 	var tags []string
 	for _, i := range event.Tags {
 		tags = append(tags, fmt.Sprintf("%v", i))
 	}
-	os.Setenv("TAGS", strings.Join(tags, ","))
+	_ = os.Setenv("TAGS", strings.Join(tags, ","))
 }
 
 func (event *Event) String() string {

--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -90,6 +90,18 @@ type KubernetesClient interface {
 	EvictPod(pod corev1.Pod) error
 }
 
+const (
+	appName = "falco-talon"
+
+	labelPartOf    = "app.kubernetes.io/part-of"
+	labelName      = "app.kubernetes.io/name"
+	labelManagedBy = "app.kubernetes.io/managed-by"
+
+	commandSleep    = "sleep"
+	annotationEndAt = "end-at"
+	volumeHostFS    = "host-fs"
+)
+
 var (
 	client          *Client
 	leaseHolderChan chan string
@@ -214,7 +226,7 @@ func (client Client) GetNode(name string) (*corev1.Node, error) {
 
 func (client Client) GetDeploymentFromPod(pod *corev1.Pod) (*appsv1.Deployment, error) {
 	podName := pod.OwnerReferences[0].Name
-	namespace := pod.ObjectMeta.Namespace
+	namespace := pod.Namespace
 	r, err := client.GetDeployment(podName, namespace)
 	if err != nil {
 		return nil, err
@@ -227,7 +239,7 @@ func (client Client) GetDeploymentFromPod(pod *corev1.Pod) (*appsv1.Deployment, 
 
 func (client Client) GetDaemonsetFromPod(pod *corev1.Pod) (*appsv1.DaemonSet, error) {
 	podName := pod.OwnerReferences[0].Name
-	namespace := pod.ObjectMeta.Namespace
+	namespace := pod.Namespace
 	r, err := client.GetDaemonSet(podName, namespace)
 	if err != nil {
 		return nil, err
@@ -240,7 +252,7 @@ func (client Client) GetDaemonsetFromPod(pod *corev1.Pod) (*appsv1.DaemonSet, er
 
 func (client Client) GetStatefulsetFromPod(pod *corev1.Pod) (*appsv1.StatefulSet, error) {
 	podName := pod.OwnerReferences[0].Name
-	namespace := pod.ObjectMeta.Namespace
+	namespace := pod.Namespace
 	r, err := client.GetStatefulSet(podName, namespace)
 	if err != nil {
 		return nil, err
@@ -253,7 +265,7 @@ func (client Client) GetStatefulsetFromPod(pod *corev1.Pod) (*appsv1.StatefulSet
 
 func (client Client) GetReplicasetFromPod(pod *corev1.Pod) (*appsv1.ReplicaSet, error) {
 	podName := pod.OwnerReferences[0].Name
-	namespace := pod.ObjectMeta.Namespace
+	namespace := pod.Namespace
 	r, err := client.GetReplicaSet(podName, namespace)
 	if err != nil {
 		return nil, err
@@ -398,14 +410,14 @@ func (client Client) GetLeaseHolder() (<-chan string, error) {
 	leaderElectionConfig := leaderelection.LeaderElectionConfig{
 		Lock: &resourcelock.LeaseLock{
 			LeaseMeta: metav1.ObjectMeta{
-				Name:      "falco-talon",
+				Name:      appName,
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/part-of": "falco-talon",
-					"app.kubernetes.io/name":    "falco-talon",
+					labelPartOf: appName,
+					labelName:   appName,
 				},
 			},
-			Client: client.Clientset.CoordinationV1(),
+			Client: client.CoordinationV1(),
 			LockConfig: resourcelock.ResourceLockConfig{
 				Identity: *utils.GetLocalIP(),
 			},
@@ -485,7 +497,7 @@ func (client Client) CreateEphemeralContainer(pod *corev1.Pod, container, name, 
 			Name:                     name,
 			Image:                    image,
 			ImagePullPolicy:          corev1.PullAlways,
-			Command:                  []string{"sleep", fmt.Sprintf("%v", ttl)},
+			Command:                  []string{commandSleep, fmt.Sprintf("%v", ttl)},
 			Stdin:                    true,
 			TTY:                      false,
 			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
@@ -612,7 +624,7 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 	execAction := new(corev1.ExecAction)
 	execAction.Command = []string{"true"}
 	probe := new(corev1.Probe)
-	probe.ProbeHandler.Exec = execAction
+	probe.Exec = execAction
 	probe.InitialDelaySeconds = int32(0)
 
 	endAt := time.Now().Local().Add(time.Duration(int64(ttl)) * time.Second)
@@ -623,12 +635,12 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: jobName + "-" + uuid,
 			Annotations: map[string]string{
-				"end-at": endAt.Format("2006-01-02 15:04:05"),
+				annotationEndAt: endAt.Format("2006-01-02 15:04:05"),
 			},
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": utils.FalcoTalonStr,
-				"app.kubernetes.io/name":       jobName,
-				"app.kubernetes.io/part-of":    utils.FalcoTalonStr,
+				labelManagedBy: utils.FalcoTalonStr,
+				labelName:      jobName,
+				labelPartOf:    utils.FalcoTalonStr,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -640,12 +652,12 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 				ObjectMeta: metav1.ObjectMeta{
 					Name: jobName + "-" + uuid,
 					Annotations: map[string]string{
-						"end-at": endAt.Format("2006-01-02 15:04:05"),
+						annotationEndAt: endAt.Format("2006-01-02 15:04:05"),
 					},
 					Labels: map[string]string{
-						"app.kubernetes.io/managed-by": utils.FalcoTalonStr,
-						"app.kubernetes.io/name":       jobName,
-						"app.kubernetes.io/part-of":    utils.FalcoTalonStr,
+						labelManagedBy: utils.FalcoTalonStr,
+						labelName:      jobName,
+						labelPartOf:    utils.FalcoTalonStr,
 					},
 				},
 				Spec: corev1.PodSpec{
@@ -653,7 +665,7 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 					Containers: []corev1.Container{
 						{
 							Name:           jobName,
-							Command:        []string{"sleep", strconv.Itoa(ttl)},
+							Command:        []string{commandSleep, strconv.Itoa(ttl)},
 							Ports:          []corev1.ContainerPort{},
 							LivenessProbe:  probe,
 							ReadinessProbe: probe,
@@ -666,7 +678,7 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "host-fs",
+									Name:      volumeHostFS,
 									MountPath: "/host",
 								},
 							},
@@ -674,7 +686,7 @@ func (client Client) CreateJob(jobName, namespace, image, node string, ttl int) 
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: "host-fs",
+							Name: volumeHostFS,
 							VolumeSource: corev1.VolumeSource{
 								HostPath: utils.Pointer(corev1.HostPathVolumeSource{Path: "/"})},
 						},

--- a/internal/nats/nats.go
+++ b/internal/nats/nats.go
@@ -87,7 +87,7 @@ func GetPublisher() *Client {
 
 func (client *Client) ConsumeMsg() (chan MessageWithContext, error) {
 	c := make(chan MessageWithContext, 20)
-	_, err := client.JetStreamContext.Subscribe(streamSubjects, func(m *nats.Msg) {
+	_, err := client.Subscribe(streamSubjects, func(m *nats.Msg) {
 		propagator := otel.GetTextMapPropagator()
 		ctx := propagator.Extract(context.Background(), propagation.HeaderCarrier(m.Header))
 
@@ -125,14 +125,14 @@ func (client *Client) PublishMsg(ctx context.Context, id, msg string) error {
 }
 
 func (client *Client) createStream(timeWindow int) error {
-	stream, err := client.JetStreamContext.StreamInfo(streamName)
+	stream, err := client.StreamInfo(streamName)
 	if err != nil {
 		if err != nats.ErrStreamNotFound {
 			return err
 		}
 	}
 	if stream == nil {
-		_, err = client.JetStreamContext.AddStream(&nats.StreamConfig{
+		_, err = client.AddStream(&nats.StreamConfig{
 			Name:              streamName,
 			Subjects:          []string{streamSubjects},
 			Duplicates:        time.Duration(timeWindow) * time.Second,

--- a/internal/otlp/metrics/metrics.go
+++ b/internal/otlp/metrics/metrics.go
@@ -22,6 +22,8 @@ import (
 
 const meterName = "github.com/falcosecurity/falco-talon"
 const metricPrefix = "falcosecurity_falco_talon_"
+const messageInit = "init"
+const categoryOtlp = "otlp"
 
 var (
 	eventCounters        metric.Int64Counter
@@ -38,7 +40,7 @@ func Init() {
 
 	exporter, err := prometheus.New()
 	if err != nil {
-		utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: "init", Category: "otlp"})
+		utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err.Error(), Message: messageInit, Category: categoryOtlp})
 		log.Fatal(err)
 	}
 
@@ -53,7 +55,7 @@ func Init() {
 	if config.Otel.MetricsEnabled {
 		otlpExporter, err2 := newOtlpMetricExporter(config)
 		if err2 != nil {
-			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: "init", Category: "otlp"})
+			utils.PrintLog(utils.FatalStr, utils.LogLine{Error: err2.Error(), Message: messageInit, Category: categoryOtlp})
 			log.Fatal(err2)
 		}
 		metricOpts = append(metricOpts, sdk.WithReader(sdk.NewPeriodicReader(otlpExporter)))

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -63,6 +63,10 @@ const (
 	trueStr                 string = "true"
 	falseStr                string = "false"
 	falcoTalonContextPrefix string = "falco-talon."
+	rulesStr                string = "rules"
+	operatorNotEqual        string = "!="
+	errMismatchParamType    string = "mismatch of type for a parameter"
+	errContinueSetting      string = "'continue' setting can be 'true' or 'false' only"
 )
 
 var rules *[]*Rule
@@ -88,7 +92,7 @@ func init() {
 func ParseRules(files []string) *[]*Rule {
 	a, r, err := extractActionsRules(files)
 	if err != nil {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: "rules"})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: err.Error(), Message: rulesStr})
 		return nil
 	}
 
@@ -122,7 +126,7 @@ func ParseRules(files []string) *[]*Rule {
 							continue
 						}
 						if rule.Actions[n].Parameters[k] != nil && ru.Kind() != rt.Kind() {
-							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "mismatch of type for a parameter", Message: "rules", Rule: rule.GetName(), Action: action.GetName()})
+							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: errMismatchParamType, Message: rulesStr, Rule: rule.GetName(), Action: action.GetName()})
 							continue
 						}
 						switch rt.Kind() {
@@ -157,7 +161,7 @@ func ParseRules(files []string) *[]*Rule {
 							continue
 						}
 						if rule.Actions[n].Output.Parameters[k] != nil && ru.Kind() != rt.Kind() {
-							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "mismatch of type for a parameter", Message: "rules", Rule: rule.GetName(), Action: action.GetName(), OutputTarget: action.Output.GetTarget()})
+							utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: errMismatchParamType, Message: rulesStr, Rule: rule.GetName(), Action: action.GetName(), OutputTarget: action.Output.GetTarget()})
 							continue
 						}
 						switch rt.Kind() {
@@ -193,7 +197,7 @@ func ParseRules(files []string) *[]*Rule {
 			rule.Match.TagsC = append(rule.Match.TagsC, t)
 		}
 		for _, j := range rule.Match.OutputFields {
-			t := strings.Split(strings.ReplaceAll(strings.ReplaceAll(j, "!=", "!"), ", ", ","), ",")
+			t := strings.Split(strings.ReplaceAll(strings.ReplaceAll(j, operatorNotEqual, "!"), ", ", ","), ",")
 			o := []outputfield{}
 			for _, k := range t {
 				if strings.Contains(k, "=") {
@@ -205,7 +209,7 @@ func ParseRules(files []string) *[]*Rule {
 				if strings.Contains(k, "!") {
 					p := strings.Split(k, "!")
 					if len(p) == 2 {
-						o = append(o, outputfield{p[0], "!=", strings.ReplaceAll(p[1], `"`, "")})
+						o = append(o, outputfield{p[0], operatorNotEqual, strings.ReplaceAll(p[1], `"`, "")})
 					}
 				}
 			}
@@ -240,7 +244,7 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 	for _, i := range files {
 		at := make([]*Action, 0)
 		rt := make([]*Rule, 0)
-		f, err := os.ReadFile(i)
+		f, err := os.ReadFile(i) // #nosec G304 -- rules file path comes from the operator configuration
 		if err != nil {
 			return nil, nil, err
 		}
@@ -396,57 +400,57 @@ func extractActionsRules(files []string) (*[]*Action, *[]*Rule, error) {
 func (rule *Rule) isValid() bool {
 	valid := true
 	if rule.Name == "" {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "all rules must have a name", Message: "rules"})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "all rules must have a name", Message: rulesStr})
 		valid = false
 	}
 	if rule.Continue != "" && rule.Continue != trueStr && rule.Continue != falseStr {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'continue' setting can be 'true' or 'false' only", Message: "rules", Rule: rule.Name})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: errContinueSetting, Message: rulesStr, Rule: rule.Name})
 		valid = false
 	}
 	if rule.DryRun != "" && rule.DryRun != trueStr && rule.DryRun != falseStr {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'dry_run' setting can be 'true' or 'false' only", Message: "rules", Rule: rule.Name})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'dry_run' setting can be 'true' or 'false' only", Message: rulesStr, Rule: rule.Name})
 		valid = false
 	}
 	if len(rule.Actions) == 0 {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "no action specified", Message: "rules", Rule: rule.Name})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "no action specified", Message: rulesStr, Rule: rule.Name})
 		valid = false
 	}
 	if len(rule.Actions) != 0 {
 		for _, i := range rule.Actions {
 			if i.Name == "" {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "action without a name", Message: "rules", Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "action without a name", Message: rulesStr, Rule: rule.Name})
 				valid = false
 			}
 			if i.Actionner == "" {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing actionner", Message: "rules", Action: i.Name, Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing actionner", Message: rulesStr, Action: i.Name, Rule: rule.Name})
 				valid = false
 			}
 			if !actionCheckRegex.MatchString(i.Actionner) {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "incorrect actionner", Message: "rules", Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "incorrect actionner", Message: rulesStr, Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
 				valid = false
 			}
 			if i.Continue != "" && i.Continue != trueStr && i.Continue != falseStr {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'continue' setting can be 'true' or 'false' only", Message: "rules", Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: errContinueSetting, Message: rulesStr, Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
 				valid = false
 			}
 			if i.IgnoreErrors != "" && i.IgnoreErrors != trueStr && i.IgnoreErrors != falseStr {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'ignore_errors' setting can be 'true' or 'false' only", Message: "rules", Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "'ignore_errors' setting can be 'true' or 'false' only", Message: rulesStr, Action: i.Name, Actionner: i.Actionner, Rule: rule.Name})
 				valid = false
 			}
 			if i.Output.Target != "" && len(i.Output.Parameters) == 0 {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing 'parameters' for the output", Message: "rules", Action: i.Name, Actionner: i.Actionner, Rule: rule.Name, OutputTarget: i.Output.Target})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: "missing 'parameters' for the output", Message: rulesStr, Action: i.Name, Actionner: i.Actionner, Rule: rule.Name, OutputTarget: i.Output.Target})
 				valid = false
 			}
 		}
 	}
 	if !priorityCheckRegex.MatchString(rule.Match.Priority) {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect priority '%v'", rule.Match.Priority), Message: "rules", Rule: rule.Name})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect priority '%v'", rule.Match.Priority), Message: rulesStr, Rule: rule.Name})
 		valid = false
 	}
 	for _, i := range rule.Match.TagsC {
 		for _, j := range i {
 			if !tagCheckRegex.MatchString(j) {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect tag '%v'", j), Message: "rules", Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect tag '%v'", j), Message: rulesStr, Rule: rule.Name})
 				valid = false
 			}
 		}
@@ -455,13 +459,13 @@ func (rule *Rule) isValid() bool {
 		t := strings.Split(strings.ReplaceAll(i, ", ", ","), ",")
 		for _, j := range t {
 			if !outputFieldKeyCheckRegex.MatchString(j) {
-				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect output field key '%v'", j), Message: "rules", Rule: rule.Name})
+				utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect output field key '%v'", j), Message: rulesStr, Rule: rule.Name})
 				valid = false
 			}
 		}
 	}
 	if err := rule.setPriorityNumberComparator(); err != nil {
-		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect priority comparator '%v'", rule.Match.PriorityComparator), Message: "rules", Rule: rule.Name})
+		utils.PrintLog(utils.ErrorStr, utils.LogLine{Error: fmt.Sprintf("incorrect priority comparator '%v'", rule.Match.PriorityComparator), Message: rulesStr, Rule: rule.Name})
 		valid = false
 	}
 	return valid
@@ -583,7 +587,7 @@ func (rule *Rule) compareOutputFields(event *events.Event) bool {
 		}
 		for _, j := range i {
 			for k, v := range event.OutputFields {
-				if j.Comparator == "!=" && j.Key == k && j.Value == fmt.Sprintf("%v", v) {
+				if j.Comparator == operatorNotEqual && j.Key == k && j.Value == fmt.Sprintf("%v", v) {
 					countF++
 				}
 				if j.Comparator == "=" && j.Key == k && j.Value == fmt.Sprintf("%v", v) {

--- a/notifiers/http/client.go
+++ b/notifiers/http/client.go
@@ -140,7 +140,7 @@ func (c *Client) Request(u string, payload any) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent: // 200, 201, 202, 204

--- a/notifiers/k8sevents/k8sevents.go
+++ b/notifiers/k8sevents/k8sevents.go
@@ -36,6 +36,7 @@ const (
 const (
 	falcoTalon string = "falco-talon"
 	defaultStr string = "default"
+	podKind    string = "Pod"
 )
 
 type Parameters struct{}
@@ -129,7 +130,7 @@ func (n Notifier) Run(log utils.LogLine) error {
 		reason = log.OutputTarget
 	}
 
-	podName := log.Objects["Pod"]
+	podName := log.Objects[podKind]
 	var podUID types.UID
 	if pod, errGetPod := client.GetPod(podName, namespace); errGetPod == nil && pod != nil {
 		podUID = pod.UID
@@ -144,7 +145,7 @@ func (n Notifier) Run(log utils.LogLine) error {
 			GenerateName: falcoTalon + "-",
 		},
 		InvolvedObject: corev1.ObjectReference{
-			Kind:      "Pod",
+			Kind:      podKind,
 			Namespace: namespace,
 			Name:      podName,
 			UID:       podUID,

--- a/outputs/aws/s3/s3.go
+++ b/outputs/aws/s3/s3.go
@@ -17,6 +17,8 @@ import (
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
+const fileStr string = "file"
+
 const (
 	Name        string = "s3"
 	Category    string = "aws"
@@ -108,7 +110,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	default:
 		var s string
 		for i, j := range data.Objects {
-			if i != "file" {
+			if i != fileStr {
 				s += j + "_"
 			}
 		}
@@ -125,7 +127,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	}
 
 	objects := map[string]string{
-		"file":   data.Name,
+		fileStr:  data.Name,
 		"bucket": parameters.Bucket,
 		"prefix": parameters.Prefix,
 		"key":    key,

--- a/outputs/file/file.go
+++ b/outputs/file/file.go
@@ -64,7 +64,7 @@ func (o Output) Checks(output *rules.Output) error {
 	}
 
 	dstFolder := os.ExpandEnv(parameters.Destination)
-	if _, err := os.Open(dstFolder); os.IsNotExist(err) {
+	if _, err := os.Open(dstFolder); os.IsNotExist(err) { // #nosec G304 -- dstFolder comes from the operator-provided configuration
 		return fmt.Errorf("folder '%v' does not exist", dstFolder)
 	}
 
@@ -91,7 +91,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	default:
 		var s string
 		for i, j := range data.Objects {
-			if i != "file" {
+			if i != Name {
 				s += j + "_"
 			}
 		}

--- a/outputs/gcs/gcs.go
+++ b/outputs/gcs/gcs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/falcosecurity/falco-talon/utils"
 )
 
+const fileStr string = "file"
+
 const (
 	Name        string = "gcs"
 	Category    string = "gcp"
@@ -130,7 +132,7 @@ func (o Output) RunWithClient(client client.GcpGcsAPI, output *rules.Output, dat
 	default:
 		var s string
 		for i, j := range data.Objects {
-			if i != "file" {
+			if i != fileStr {
 				s += j + "_"
 			}
 		}
@@ -138,7 +140,7 @@ func (o Output) RunWithClient(client client.GcpGcsAPI, output *rules.Output, dat
 	}
 
 	objects := map[string]string{
-		"file":   data.Name,
+		fileStr:  data.Name,
 		"bucket": parameters.Bucket,
 		"prefix": parameters.Prefix,
 		"key":    key,
@@ -165,7 +167,7 @@ func putObject(ctx context.Context, storageClient client.GcpGcsAPI, bucketName, 
 	bucket := storageClient.Bucket(bucketName)
 	objectName := prefix + key
 	wc := bucket.Object(objectName).NewWriter(ctx)
-	defer wc.Close()
+	defer func() { _ = wc.Close() }()
 
 	if _, err := wc.Write(data.Bytes); err != nil {
 		return err

--- a/outputs/minio/minio.go
+++ b/outputs/minio/minio.go
@@ -35,6 +35,7 @@ const (
 
 const (
 	defaultContentType string = "text/plain; charset=UTF-8"
+	fileStr            string = "file"
 )
 
 type Parameters struct {
@@ -108,7 +109,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	default:
 		var s string
 		for i, j := range data.Objects {
-			if i != "file" {
+			if i != fileStr {
 				s += j + "_"
 			}
 		}
@@ -116,7 +117,7 @@ func (o Output) Run(output *rules.Output, data *models.Data) (utils.LogLine, err
 	}
 
 	objects := map[string]string{
-		"file":   data.Name,
+		fileStr:  data.Name,
 		"bucket": parameters.Bucket,
 		"prefix": parameters.Prefix,
 		"key":    key,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -177,7 +177,7 @@ func PrintLog(level string, line LogLine) {
 
 func SetFields(structure any, fields map[string]any) any {
 	valueOf := reflect.ValueOf(structure)
-	if valueOf.Kind() == reflect.Ptr {
+	if valueOf.Kind() == reflect.Pointer {
 		valueOf = valueOf.Elem()
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**Any specific area of the project related to this PR?**

/area core

**What this PR does / why we need it**:

The lint workflow requests golangci-lint with `version: latest`. `latest` now
resolves to golangci-lint **v2.x**, but `.golangci.yml` was still written in the
**v1** configuration format, so every lint run fails to even start with:

```
Error: can't load config: unsupported version of the configuration: ""

(exit code 3) — regardless of the change under review. Pinning back to
golangci-lint v1 is not a viable workaround either: its last release (v1.64.8)
is built with go1.24 and refuses to lint this module, which targets `go 1.25.0`:

the Go language version (go1.24) used to build golangci-lint is lower than the
targeted Go version (1.25.0)
```


The only path forward is to migrate to golangci-lint v2 (built with go1.25) and
resolve the findings it reports.

**Configuration (`.golangci.yml`)**:
- migrated to the v2 schema (`formatters` section, `linters.default` /
  `linters.settings` / `linters.exclusions`);
- removed linters that no longer exist in v2 (`gosimple` and `stylecheck` are
  now folded into `staticcheck`; `golint`, `deadcode`, `varcheck`, `scopelint`
  are gone);
- disabled the revive `exported` and `package-comments` rules. Satisfying them
  would mean adding a doc comment to every exported symbol and package across
  ~47 files (400+ findings); this project has never documented them, so that is
  intentionally left out of scope for this fix;
- disabled the per-linter issue caps so the full backlog is visible.

**Workflow (`.github/workflows/lint.yml`)**:
- bumped `golangci/golangci-lint-action` from `v4` to `v7` (the v2-compatible
  major; v4 targets golangci-lint v1 and passes the removed `--out-format` flag);
- bumped `actions/setup-go` from `1.22` to `1.25` to match `go.mod`.

**Code fixes** for the findings surfaced by v2 (no behavior change):
- `goconst`: repeated string literals extracted into constants;
- `errcheck`: returned errors now handled or explicitly ignored
  (`Close`, `Fprintf`, `Flush`, `Setenv`);
- `gosec` G304: justified `// #nosec` directives where the file path comes from
  the operator-provided configuration (rules file, output destination);
- `govet`: `reflect.Ptr` → `reflect.Pointer` (non-deprecated);
- `staticcheck` QF1008: redundant embedded-field selectors removed
  (`ObjectMeta`, `JetStreamContext`, `Clientset`, `ProbeHandler`).

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Files changed: `.golangci.yml`, `.github/workflows/lint.yml`, and 35 `.go` files
(constants, error handling, selector simplifications only — no doc-comment
churn). Verified locally with golangci-lint v2.12.2:

- `golangci-lint run ./...` → `0 issues`
- `go build ./...`, `go vet ./...`, `gofmt -l .` → clean
- `go test ./...` → all green
